### PR TITLE
event 목록 조회 api 생성

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -17,11 +17,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.teamddd.duckmap.dto.ArtistRes;
-import com.teamddd.duckmap.dto.ArtistTypeRes;
 import com.teamddd.duckmap.dto.ImageRes;
 import com.teamddd.duckmap.dto.Result;
 import com.teamddd.duckmap.dto.ReviewRes;
+import com.teamddd.duckmap.dto.artist.ArtistRes;
+import com.teamddd.duckmap.dto.artist.ArtistTypeRes;
 import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
 import com.teamddd.duckmap.dto.event.event.CreateEventReq;
 import com.teamddd.duckmap.dto.event.event.CreateEventRes;

--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -28,6 +28,7 @@ import com.teamddd.duckmap.dto.event.event.CreateEventRes;
 import com.teamddd.duckmap.dto.event.event.EventRes;
 import com.teamddd.duckmap.dto.event.event.EventSearchParam;
 import com.teamddd.duckmap.dto.event.event.EventsRes;
+import com.teamddd.duckmap.dto.event.event.HashtagRes;
 import com.teamddd.duckmap.dto.event.event.UpdateEventReq;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -276,5 +277,30 @@ public class EventController {
 				)
 				.build()
 		));
+	}
+
+	@Operation(summary = "오늘 진행중인 이벤트 해시태그 목록 조회")
+	@GetMapping("/hashtags/today")
+	public Result<List<HashtagRes>> getTodayHashtags() {
+		return Result.<List<HashtagRes>>builder()
+			.data(List.of(
+				HashtagRes.builder()
+					.eventId(1L)
+					.hashtag("#뫄뫄 #생일_축하해")
+					.build(),
+				HashtagRes.builder()
+					.eventId(2L)
+					.hashtag("#소녀시대 #10주년")
+					.build(),
+				HashtagRes.builder()
+					.eventId(3L)
+					.hashtag("#뫄뫄_탄신 #벌써10000일")
+					.build(),
+				HashtagRes.builder()
+					.eventId(4L)
+					.hashtag("#드라마 #대박나자")
+					.build()
+			))
+			.build();
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -25,6 +26,7 @@ import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
 import com.teamddd.duckmap.dto.event.event.CreateEventReq;
 import com.teamddd.duckmap.dto.event.event.CreateEventRes;
 import com.teamddd.duckmap.dto.event.event.EventRes;
+import com.teamddd.duckmap.dto.event.event.EventSearchParam;
 import com.teamddd.duckmap.dto.event.event.EventsRes;
 import com.teamddd.duckmap.dto.event.event.UpdateEventReq;
 
@@ -132,6 +134,77 @@ public class EventController {
 	@DeleteMapping("/{id}")
 	public Result<Void> deleteEvent(@PathVariable Long id) {
 		return Result.<Void>builder().build();
+	}
+
+	@Operation(summary = "이벤트 목록 조회")
+	@GetMapping
+	public Page<EventsRes> getEvents(Pageable pageable, @ModelAttribute EventSearchParam eventSearchParam) {
+		ImageRes imageRes = ImageRes.builder()
+			.apiUrl("/images/")
+			.filename("filename.png")
+			.build();
+
+		return new PageImpl<>(List.of(
+			EventsRes.builder()
+				.id(1L)
+				.storeName("이벤트1")
+				.address("서울 서초동")
+				.artists(List.of(
+					ArtistRes.builder()
+						.id(2L)
+						.groupId(1L)
+						.name("태연")
+						.image(imageRes)
+						.artistType(
+							ArtistTypeRes.builder()
+								.id(1L)
+								.type("아이돌")
+								.build()
+						)
+						.build()
+				))
+				.categories(List.of(
+					EventCategoryRes.builder()
+						.id(1L)
+						.category("생일카페")
+						.build()
+				))
+				.image(
+					imageRes
+				)
+				.build(),
+			EventsRes.builder()
+				.id(2L)
+				.storeName("이벤트2")
+				.address("서울 한남동")
+				.artists(List.of(
+					ArtistRes.builder()
+						.id(1L)
+						.groupId(null)
+						.name("소녀시대")
+						.image(imageRes)
+						.artistType(
+							ArtistTypeRes.builder()
+								.id(2L)
+								.type("그룹")
+								.build()
+						)
+						.build()
+				))
+				.categories(List.of(
+					EventCategoryRes.builder()
+						.id(2L)
+						.category("전시회")
+						.build()
+				))
+				.image(
+					ImageRes.builder()
+						.apiUrl("/images/")
+						.filename("event_image2.jpg")
+						.build()
+				)
+				.build()
+		));
 	}
 
 	@Operation(summary = "나의 이벤트 목록 조회")

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventRes.java
@@ -3,9 +3,9 @@ package com.teamddd.duckmap.dto.event.event;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.teamddd.duckmap.dto.ArtistRes;
 import com.teamddd.duckmap.dto.ImageRes;
 import com.teamddd.duckmap.dto.ReviewRes;
+import com.teamddd.duckmap.dto.artist.ArtistRes;
 import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
 
 import lombok.Builder;

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventSearchParam.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventSearchParam.java
@@ -1,0 +1,11 @@
+package com.teamddd.duckmap.dto.event.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EventSearchParam {
+	private Long artistId;
+	private boolean inProgress;
+}

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventsRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventsRes.java
@@ -2,8 +2,8 @@ package com.teamddd.duckmap.dto.event.event;
 
 import java.util.List;
 
-import com.teamddd.duckmap.dto.ArtistRes;
 import com.teamddd.duckmap.dto.ImageRes;
+import com.teamddd.duckmap.dto.artist.ArtistRes;
 import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
 
 import lombok.Builder;

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/HashtagRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/HashtagRes.java
@@ -1,0 +1,11 @@
+package com.teamddd.duckmap.dto.event.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HashtagRes {
+	private Long eventId;
+	private String hashtag;
+}


### PR DESCRIPTION
## Description

> event 목록 조회 api 생성 & Artist dto import 경로 변경

## Changes

- GET /events
- GET /events/hashtags/today
- Artist dto import 경로 변경

## ETC
이벤트 목록 조회 검색 조건은 일단 아티스트, 진행중 여부만 넣었습니다
개발하다가 mock-api랑 병합했더니 artist dto import 에러가 나서 수정했더니 커밋이 지저분해졌네요ㅠㅠ