### PR TITLE
User CRUD api 생성

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.teamddd.duckmap.dto.LoginUserReq;
-import com.teamddd.duckmap.dto.LoginUserRes;
 import com.teamddd.duckmap.dto.Result;
+import com.teamddd.duckmap.dto.user.auth.LoginUserReq;
+import com.teamddd.duckmap.dto.user.auth.LoginUserRes;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;

--- a/src/main/java/com/teamddd/duckmap/controller/UserController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/UserController.java
@@ -35,7 +35,13 @@ public class UserController {
 	@Operation(summary = "회원 가입")
 	@PostMapping
 	public Result<CreateUserRes> createUser(@Validated @RequestBody CreateUserReq createUserReq) {
-		return Result.<CreateUserRes>builder().data(CreateUserRes.builder().id(1L).build()).build();
+		return Result.<CreateUserRes>builder()
+			.data(
+				CreateUserRes.builder()
+					.id(1L)
+					.build()
+			)
+			.build();
 	}
 
 	@Operation(summary = "회원 정보 조회", description = "로그인한 회원 정보 조회")
@@ -46,7 +52,12 @@ public class UserController {
 				.id(1L)
 				.username("user1")
 				.email("sample@naver.com")
-				.userProfile(ImageRes.builder().apiUrl("/images/").filename("user1.jpg").build())
+				.userProfile(
+					ImageRes.builder()
+						.apiUrl("/images/")
+						.filename("user1.jpg")
+						.build()
+				)
 				.loginAt(LocalDateTime.now())
 				.build())
 			.build();

--- a/src/main/java/com/teamddd/duckmap/controller/UserController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/UserController.java
@@ -1,0 +1,73 @@
+package com.teamddd.duckmap.controller;
+
+import java.time.LocalDateTime;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.teamddd.duckmap.dto.ImageRes;
+import com.teamddd.duckmap.dto.Result;
+import com.teamddd.duckmap.dto.user.CreateUserReq;
+import com.teamddd.duckmap.dto.user.CreateUserRes;
+import com.teamddd.duckmap.dto.user.UpdatePasswordReq;
+import com.teamddd.duckmap.dto.user.UpdateUserReq;
+import com.teamddd.duckmap.dto.user.UserRes;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+	@Operation(summary = "회원 가입")
+	@PostMapping
+	public Result<CreateUserRes> createUser(@Validated @RequestBody CreateUserReq createUserReq) {
+		return Result.<CreateUserRes>builder().data(CreateUserRes.builder().id(1L).build()).build();
+	}
+
+	@Operation(summary = "회원 정보 조회", description = "로그인한 회원 정보 조회")
+	@GetMapping("/me")
+	public Result<UserRes> getUserInfo(HttpSession session) {
+		return Result.<UserRes>builder()
+			.data(UserRes.builder()
+				.id(1L)
+				.username("user1")
+				.email("sample@naver.com")
+				.userProfile(ImageRes.builder().apiUrl("/images/").filename("user1.jpg").build())
+				.loginAt(LocalDateTime.now())
+				.build())
+			.build();
+	}
+
+	@Operation(summary = "회원정보 수정", description = "로그인한 회원의 닉네임, 프로필 사진 변경 요청")
+	@PutMapping("/me")
+	public Result<Void> updateUser(HttpSession session, @Validated @RequestBody UpdateUserReq updateUserReq) {
+		return Result.<Void>builder().build();
+	}
+
+	@Operation(summary = "비밀번호 변경", description = "로그인한 회원 비밀번호 변경")
+	@PatchMapping("/me/password")
+	public Result<Void> updatePassword(@Validated @RequestBody UpdatePasswordReq updatePasswordReq) {
+		return Result.<Void>builder().build();
+	}
+
+	@Operation(summary = "회원 탈퇴")
+	@DeleteMapping("/me")
+	public Result<Void> deleteUser(HttpSession session) {
+		return Result.<Void>builder().build();
+	}
+
+}

--- a/src/main/java/com/teamddd/duckmap/dto/user/CreateUserReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/CreateUserReq.java
@@ -1,0 +1,20 @@
+package com.teamddd.duckmap.dto.user;
+
+import java.time.LocalDateTime;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.Getter;
+
+@Getter
+public class CreateUserReq {
+	@NotBlank
+	private String username;
+	@NotBlank
+	private String email;
+	@NotBlank
+	private String password;
+	private String salt;
+	private String image;
+	private LocalDateTime loginAt;
+}

--- a/src/main/java/com/teamddd/duckmap/dto/user/CreateUserReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/CreateUserReq.java
@@ -1,7 +1,6 @@
 package com.teamddd.duckmap.dto.user;
 
-import java.time.LocalDateTime;
-
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
 import lombok.Getter;
@@ -11,10 +10,8 @@ public class CreateUserReq {
 	@NotBlank
 	private String username;
 	@NotBlank
+	@Email
 	private String email;
 	@NotBlank
 	private String password;
-	private String salt;
-	private String image;
-	private LocalDateTime loginAt;
 }

--- a/src/main/java/com/teamddd/duckmap/dto/user/CreateUserRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/CreateUserRes.java
@@ -1,0 +1,10 @@
+package com.teamddd.duckmap.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateUserRes {
+	private Long id;
+}

--- a/src/main/java/com/teamddd/duckmap/dto/user/UpdatePasswordReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/UpdatePasswordReq.java
@@ -1,0 +1,13 @@
+package com.teamddd.duckmap.dto.user;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.Getter;
+
+@Getter
+public class UpdatePasswordReq {
+	@NotBlank
+	private String currentPassword;
+	@NotBlank
+	private String newPassword;
+}

--- a/src/main/java/com/teamddd/duckmap/dto/user/UpdateUserReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/UpdateUserReq.java
@@ -1,0 +1,12 @@
+package com.teamddd.duckmap.dto.user;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateUserReq {
+	@NotBlank
+	private String username;
+	private String image;
+}

--- a/src/main/java/com/teamddd/duckmap/dto/user/UserRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/UserRes.java
@@ -1,0 +1,18 @@
+package com.teamddd.duckmap.dto.user;
+
+import java.time.LocalDateTime;
+
+import com.teamddd.duckmap.dto.ImageRes;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserRes {
+	private Long id;
+	private String username;
+	private String email;
+	private ImageRes userProfile;
+	private LocalDateTime loginAt;
+}

--- a/src/main/java/com/teamddd/duckmap/dto/user/auth/LoginUserReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/auth/LoginUserReq.java
@@ -1,4 +1,4 @@
-package com.teamddd.duckmap.dto;
+package com.teamddd.duckmap.dto.user.auth;
 
 import javax.validation.constraints.NotBlank;
 

--- a/src/main/java/com/teamddd/duckmap/dto/user/auth/LoginUserRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/auth/LoginUserRes.java
@@ -1,4 +1,4 @@
-package com.teamddd.duckmap.dto;
+package com.teamddd.duckmap.dto.user.auth;
 
 import lombok.Builder;
 import lombok.Getter;


### PR DESCRIPTION
## Description

> User CRUD api 생성

## Changes

- UserController
  - POST /users 회원가입
  - GET /users/me 로그인한 회원 정보 조회
  - PUT  /users/me 로그인한 회원의 닉네임, 프로필 사진 변경 요청
  - PATCH /users/me/password 로그인 한 회원의 비밀번호 변경
  - GET /users/me 회원 탈퇴
- dto/user/auth로 auth 관련 dto 이동
- dto/user로 user 관련 dto 이동

## ETC
- 닉네임 중복 확인 기능 삭제 고려
- 비밀번호 재설정 기능 개발 보류