### PR TITLE
Fix: #89 - 북마크 폴더 내부 이벤트 조회 오류 수정 

### DIFF
--- a/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkFolderEventDto.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkFolderEventDto.java
@@ -1,0 +1,18 @@
+package com.teamddd.duckmap.dto.event.bookmark;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventBookmark;
+import lombok.Getter;
+
+@Getter
+public class BookmarkFolderEventDto {
+	private final Event event;
+	private final EventBookmark eventBookmark;
+
+	@QueryProjection
+	public BookmarkFolderEventDto(Event event, EventBookmark eventBookmark) {
+		this.event = event;
+		this.eventBookmark = eventBookmark;
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepository.java
@@ -4,5 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.teamddd.duckmap.entity.EventBookmarkFolder;
 
-public interface BookmarkFolderRepository extends JpaRepository<EventBookmarkFolder, Long> {
+public interface BookmarkFolderRepository
+	extends JpaRepository<EventBookmarkFolder, Long>, BookmarkFolderRepositoryCustom {
 }

--- a/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryCustom.java
+++ b/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.teamddd.duckmap.repository;
+
+import com.teamddd.duckmap.dto.event.bookmark.BookmarkFolderEventDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BookmarkFolderRepositoryCustom {
+	Page<BookmarkFolderEventDto> findBookmarkedEvents(Long bookmarkFolderId, Pageable pageable);
+}

--- a/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
+++ b/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.teamddd.duckmap.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.teamddd.duckmap.dto.event.bookmark.BookmarkFolderEventDto;
+import com.teamddd.duckmap.dto.event.bookmark.QBookmarkFolderEventDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.teamddd.duckmap.entity.QEvent.event;
+import static com.teamddd.duckmap.entity.QEventBookmark.eventBookmark;
+
+public class BookmarkFolderRepositoryImpl implements BookmarkFolderRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	public BookmarkFolderRepositoryImpl(EntityManager em) {
+		this.queryFactory = new JPAQueryFactory(em);
+	}
+
+	@Override
+	public Page<BookmarkFolderEventDto> findBookmarkedEvents(Long bookmarkFolderId, Pageable pageable) {
+		List<BookmarkFolderEventDto> events = queryFactory.select(
+						new QBookmarkFolderEventDto(
+								event,
+								eventBookmark
+						))
+				.from(eventBookmark)
+				.join(eventBookmark.event, event)
+				.where(eventBookmark.eventBookmarkFolder.id.eq(bookmarkFolderId))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.fetch();
+
+		JPAQuery<Long> countQuery = queryFactory.select(event.count())
+				.from(eventBookmark)
+				.join(eventBookmark.event, event)
+				.where(eventBookmark.eventBookmarkFolder.id.eq(bookmarkFolderId));
+
+		return PageableExecutionUtils.getPage(events, pageable, countQuery::fetchOne);
+	}
+
+}

--- a/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
+++ b/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
@@ -30,13 +30,15 @@ public class BookmarkFolderRepositoryImpl implements BookmarkFolderRepositoryCus
 						))
 				.from(event)
 				.join(eventBookmark).on(event.eq(eventBookmark.event))
+				.where(eventBookmark.eventBookmarkFolder.id.eq(bookmarkFolderId))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.fetch();
 
 		JPAQuery<Long> countQuery = queryFactory.select(event.count())
 				.from(event)
-				.join(eventBookmark).on(event.eq(eventBookmark.event));
+				.join(eventBookmark).on(event.eq(eventBookmark.event))
+				.where(eventBookmark.eventBookmarkFolder.id.eq(bookmarkFolderId));
 
 		return PageableExecutionUtils.getPage(events, pageable, countQuery::fetchOne);
 	}

--- a/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
+++ b/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static com.teamddd.duckmap.entity.QEvent.event;
 import static com.teamddd.duckmap.entity.QEventBookmark.eventBookmark;
+import static com.teamddd.duckmap.entity.QEventBookmarkFolder.eventBookmarkFolder;
 
 public class BookmarkFolderRepositoryImpl implements BookmarkFolderRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
@@ -28,17 +29,19 @@ public class BookmarkFolderRepositoryImpl implements BookmarkFolderRepositoryCus
 								event,
 								eventBookmark
 						))
-				.from(eventBookmark)
-				.join(eventBookmark.event, event)
-				.where(eventBookmark.eventBookmarkFolder.id.eq(bookmarkFolderId))
+				.from(event)
+				.leftJoin(eventBookmark).on(event.eq(eventBookmark.event))
+				.leftJoin(eventBookmark.eventBookmarkFolder, eventBookmarkFolder)
+				.on(eventBookmarkFolder.id.eq(bookmarkFolderId))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.fetch();
 
 		JPAQuery<Long> countQuery = queryFactory.select(event.count())
-				.from(eventBookmark)
-				.join(eventBookmark.event, event)
-				.where(eventBookmark.eventBookmarkFolder.id.eq(bookmarkFolderId));
+				.from(event)
+				.leftJoin(eventBookmark).on(event.eq(eventBookmark.event))
+				.leftJoin(eventBookmark.eventBookmarkFolder, eventBookmarkFolder)
+				.on(eventBookmarkFolder.id.eq(bookmarkFolderId));
 
 		return PageableExecutionUtils.getPage(events, pageable, countQuery::fetchOne);
 	}

--- a/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
+++ b/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 import static com.teamddd.duckmap.entity.QEvent.event;
 import static com.teamddd.duckmap.entity.QEventBookmark.eventBookmark;
-import static com.teamddd.duckmap.entity.QEventBookmarkFolder.eventBookmarkFolder;
 
 public class BookmarkFolderRepositoryImpl implements BookmarkFolderRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
@@ -30,18 +29,14 @@ public class BookmarkFolderRepositoryImpl implements BookmarkFolderRepositoryCus
 								eventBookmark
 						))
 				.from(event)
-				.leftJoin(eventBookmark).on(event.eq(eventBookmark.event))
-				.leftJoin(eventBookmark.eventBookmarkFolder, eventBookmarkFolder)
-				.on(eventBookmarkFolder.id.eq(bookmarkFolderId))
+				.join(eventBookmark).on(event.eq(eventBookmark.event))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.fetch();
 
 		JPAQuery<Long> countQuery = queryFactory.select(event.count())
 				.from(event)
-				.leftJoin(eventBookmark).on(event.eq(eventBookmark.event))
-				.leftJoin(eventBookmark.eventBookmarkFolder, eventBookmarkFolder)
-				.on(eventBookmarkFolder.id.eq(bookmarkFolderId));
+				.join(eventBookmark).on(event.eq(eventBookmark.event));
 
 		return PageableExecutionUtils.getPage(events, pageable, countQuery::fetchOne);
 	}

--- a/src/test/java/com/teamddd/duckmap/BookmarkFolderRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/BookmarkFolderRepositoryTest.java
@@ -16,8 +16,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
-import java.time.LocalDate;
-import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,54 +35,64 @@ public class BookmarkFolderRepositoryTest {
 		User user = User.builder().build();
 		em.persist(user);
 
-		Event event = createEvent(user, "event1", LocalDate.now(), LocalDate.now(), "#hashtag");
-		Event event2 = createEvent(user, "event2", LocalDate.now(), LocalDate.now(), "#hashtag");
-		Event event3 = createEvent(user, "event3", LocalDate.now(), LocalDate.now(), "#hashtag");
+		Event event = createEvent(user, "event1");
+		Event event2 = createEvent(user, "event2");
+		Event event3 = createEvent(user, "event3");
+		Event event4 = createEvent(user, "event4");
 		em.persist(event);
 		em.persist(event2);
 		em.persist(event3);
+		em.persist(event4);
 
-		EventBookmarkFolder eventBookmarkFolder = createEventBookmarkFolder();
+		EventBookmarkFolder eventBookmarkFolder = createEventBookmarkFolder("folder1");
+		EventBookmarkFolder eventBookmarkFolder2 = createEventBookmarkFolder("folder2");
 		em.persist(eventBookmarkFolder);
+		em.persist(eventBookmarkFolder2);
 
 		EventBookmark eventBookmark = createEventBookmark(user, event, eventBookmarkFolder);
 		EventBookmark eventBookmark2 = createEventBookmark(user, event2, eventBookmarkFolder);
-		EventBookmark eventBookmark3 = createEventBookmark(user, event3, eventBookmarkFolder);
-
-		eventBookmark.getEventBookmarkFolder().getEventBookmarks().add(eventBookmark);
-		eventBookmark2.getEventBookmarkFolder().getEventBookmarks().add(eventBookmark2);
-		eventBookmark3.getEventBookmarkFolder().getEventBookmarks().add(eventBookmark3);
+		EventBookmark eventBookmark3 = createEventBookmark(user, event, eventBookmarkFolder2);
+		EventBookmark eventBookmark4 = createEventBookmark(user, event3, eventBookmarkFolder2);
+		EventBookmark eventBookmark5 = createEventBookmark(user, event4, eventBookmarkFolder2);
 
 		em.persist(eventBookmark);
 		em.persist(eventBookmark2);
 		em.persist(eventBookmark3);
+		em.persist(eventBookmark4);
+		em.persist(eventBookmark5);
 
-		PageRequest pageRequest = PageRequest.of(0, 3);
-
+		PageRequest pageRequest = PageRequest.of(0, 2);
+		PageRequest pageRequest2 = PageRequest.of(0, 2);
 		//when
 		Page<BookmarkFolderEventDto> bookmarkedEvents = bookmarkFolderRepository
 				.findBookmarkedEvents(eventBookmarkFolder.getId(), pageRequest);
-
+		Page<BookmarkFolderEventDto> bookmarkedEvents2 = bookmarkFolderRepository
+				.findBookmarkedEvents(eventBookmarkFolder2.getId(), pageRequest2);
 		//then
-		assertThat(bookmarkedEvents).hasSize(3)
+		assertThat(bookmarkedEvents).hasSize(2)
 				.extracting("event.id", "event.storeName", "eventBookmark.id")
 				.containsExactly(Tuple.tuple(event.getId(), "event1", eventBookmark.getId()),
-						Tuple.tuple(event2.getId(), "event2", eventBookmark2.getId()),
-						Tuple.tuple(event3.getId(), "event3", eventBookmark3.getId()));
-
-		assertThat(bookmarkedEvents.getTotalElements()).isEqualTo(3);
+						Tuple.tuple(event2.getId(), "event2", eventBookmark2.getId()));
+		assertThat(bookmarkedEvents.getTotalElements()).isEqualTo(2);
 		assertThat(bookmarkedEvents.getTotalPages()).isEqualTo(1);
+
+		assertThat(bookmarkedEvents2).hasSize(2)
+				.extracting("event.id", "event.storeName", "eventBookmark.id")
+				.containsExactlyInAnyOrder(Tuple.tuple(event.getId(), "event1", eventBookmark3.getId()),
+						Tuple.tuple(event3.getId(), "event3", eventBookmark4.getId()));
+		assertThat(bookmarkedEvents2.getTotalElements()).isEqualTo(3);
+		assertThat(bookmarkedEvents2.getTotalPages()).isEqualTo(2);
 	}
 
-	private Event createEvent(User user, String storeName, LocalDate fromDate, LocalDate toDate, String hashtag) {
-		return Event.builder().user(user).storeName(storeName).fromDate(fromDate).toDate(toDate).hashtag(hashtag).build();
+	private Event createEvent(User user, String storeName) {
+		return Event.builder().user(user).storeName(storeName).build();
 	}
 
 	private EventBookmark createEventBookmark(User user, Event event, EventBookmarkFolder eventBookmarkFolder) {
 		return EventBookmark.builder().user(user).event(event).eventBookmarkFolder(eventBookmarkFolder).build();
 	}
 
-	private EventBookmarkFolder createEventBookmarkFolder() {
-		return EventBookmarkFolder.builder().eventBookmarks(new ArrayList<>()).build();
+	private EventBookmarkFolder createEventBookmarkFolder(String name) {
+		return EventBookmarkFolder.builder().name(name).build();
 	}
 }

--- a/src/test/java/com/teamddd/duckmap/BookmarkFolderRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/BookmarkFolderRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.teamddd.duckmap;
+
+import com.teamddd.duckmap.dto.event.bookmark.BookmarkFolderEventDto;
+import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventBookmark;
+import com.teamddd.duckmap.entity.EventBookmarkFolder;
+import com.teamddd.duckmap.entity.User;
+import com.teamddd.duckmap.repository.BookmarkFolderRepository;
+import org.assertj.core.groups.Tuple;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest
+@Transactional
+public class BookmarkFolderRepositoryTest {
+	@Autowired
+	BookmarkFolderRepository bookmarkFolderRepository;
+	@Autowired
+	EntityManager em;
+
+	@DisplayName("bookmarkfolderId로 이벤트 목록 조회")
+	@Test
+	public void findBookmarkedEvents() throws Exception {
+		//given
+		User user = User.builder().build();
+		em.persist(user);
+
+		Event event = createEvent(user, "event1", LocalDate.now(), LocalDate.now(), "#hashtag");
+		em.persist(event);
+
+
+		EventBookmark eventBookmark = createEventBookmark(user, event);
+		em.persist(eventBookmark);
+
+		EventBookmarkFolder eventBookmarkFolder1 = createEventBookmarkFolder(eventBookmark);
+		em.persist(eventBookmarkFolder1);
+		PageRequest pageRequest = PageRequest.of(0, 2);
+
+		//when
+		Page<BookmarkFolderEventDto> bookmarkedEvents = bookmarkFolderRepository.findBookmarkedEvents(eventBookmarkFolder1.getId(), pageRequest);
+
+		//then
+		assertThat(bookmarkedEvents).hasSize(1).extracting("event.id", "event.storeName", "eventBookmark.id").containsExactly(Tuple.tuple(event.getId(), "event1", eventBookmark.getId()));
+
+		assertThat(bookmarkedEvents.getTotalElements()).isEqualTo(1);
+		assertThat(bookmarkedEvents.getTotalPages()).isEqualTo(1);
+	}
+
+	private Event createEvent(User user, String storeName, LocalDate fromDate, LocalDate toDate, String hashtag) {
+		return Event.builder().user(user).storeName(storeName).fromDate(fromDate).toDate(toDate).hashtag(hashtag).build();
+	}
+
+	private EventBookmark createEventBookmark(User user, Event event) {
+		return EventBookmark.builder().user(user).event(event).build();
+	}
+
+	private EventBookmarkFolder createEventBookmarkFolder(EventBookmark bookmark) {
+		return EventBookmarkFolder.builder().eventBookmarks(List.of(bookmark)).build();
+	}
+}

--- a/src/test/java/com/teamddd/duckmap/BookmarkFolderRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/BookmarkFolderRepositoryTest.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDate;
-import java.util.List;
+import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,21 +44,27 @@ public class BookmarkFolderRepositoryTest {
 		em.persist(event2);
 		em.persist(event3);
 
-		EventBookmark eventBookmark = createEventBookmark(user, event);
-		EventBookmark eventBookmark2 = createEventBookmark(user, event2);
-		EventBookmark eventBookmark3 = createEventBookmark(user, event3);
+		EventBookmarkFolder eventBookmarkFolder = createEventBookmarkFolder();
+		em.persist(eventBookmarkFolder);
+
+		EventBookmark eventBookmark = createEventBookmark(user, event, eventBookmarkFolder);
+		EventBookmark eventBookmark2 = createEventBookmark(user, event2, eventBookmarkFolder);
+		EventBookmark eventBookmark3 = createEventBookmark(user, event3, eventBookmarkFolder);
+
+		eventBookmark.getEventBookmarkFolder().getEventBookmarks().add(eventBookmark);
+		eventBookmark2.getEventBookmarkFolder().getEventBookmarks().add(eventBookmark2);
+		eventBookmark3.getEventBookmarkFolder().getEventBookmarks().add(eventBookmark3);
 
 		em.persist(eventBookmark);
 		em.persist(eventBookmark2);
 		em.persist(eventBookmark3);
 
-		EventBookmarkFolder eventBookmarkFolder = createEventBookmarkFolder(List.of(eventBookmark, eventBookmark2, eventBookmark3));
-		em.persist(eventBookmarkFolder);
 		PageRequest pageRequest = PageRequest.of(0, 3);
 
 		//when
 		Page<BookmarkFolderEventDto> bookmarkedEvents = bookmarkFolderRepository
 				.findBookmarkedEvents(eventBookmarkFolder.getId(), pageRequest);
+
 		//then
 		assertThat(bookmarkedEvents).hasSize(3)
 				.extracting("event.id", "event.storeName", "eventBookmark.id")
@@ -74,11 +80,11 @@ public class BookmarkFolderRepositoryTest {
 		return Event.builder().user(user).storeName(storeName).fromDate(fromDate).toDate(toDate).hashtag(hashtag).build();
 	}
 
-	private EventBookmark createEventBookmark(User user, Event event) {
-		return EventBookmark.builder().user(user).event(event).build();
+	private EventBookmark createEventBookmark(User user, Event event, EventBookmarkFolder eventBookmarkFolder) {
+		return EventBookmark.builder().user(user).event(event).eventBookmarkFolder(eventBookmarkFolder).build();
 	}
 
-	private EventBookmarkFolder createEventBookmarkFolder(List<EventBookmark> bookmarks) {
-		return EventBookmarkFolder.builder().eventBookmarks(bookmarks).build();
+	private EventBookmarkFolder createEventBookmarkFolder() {
+		return EventBookmarkFolder.builder().eventBookmarks(new ArrayList<>()).build();
 	}
 }


### PR DESCRIPTION
## Description

> 북마크 폴더 내부 이벤트 조회 오류 수정 및 기능 개선

## Changes
- BookmarkFolderRepositoryImpl 쿼리dsl 수정 
  - Where 절 추가
  - left join 대신 join 사용
- BookmarkFolderRepositoryTest 내용 추가
- BookmarkFolderRepositoryTest @Test import 변경
- BookmarkFolderRepositoryTest 
  - createEventBookmark, createEventBookmarkFolder 연관관계의 주인 고려하여 수정
  - 북마크 생성시 필수로 북마크 폴더가 필요함
  - 컬렉션 조회 최적화 적용
  - 폴더 여러개 생성 후 테스트 적용
  - 이벤트 생성시 storeName만 지정(이벤트를 구분할 수 있는 정보 최소화하여 적용)
 

## ETC
