### PR TITLE
Feat: #167 - MemberUtils 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/advice/AuthAdvice.java
+++ b/src/main/java/com/teamddd/duckmap/advice/AuthAdvice.java
@@ -1,0 +1,27 @@
+package com.teamddd.duckmap.advice;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.teamddd.duckmap.common.ExceptionCodeMessage;
+import com.teamddd.duckmap.dto.ErrorResult;
+import com.teamddd.duckmap.exception.InvalidTokenException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class AuthAdvice {
+
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	@ExceptionHandler
+	public ErrorResult nonExistentUserException(InvalidTokenException ex) {
+		return ErrorResult.builder()
+			.code(ExceptionCodeMessage.INVALID_TOKEN_EXCEPTION.code())
+			.message(ex.getMessage())
+			.build();
+	}
+
+}

--- a/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
+++ b/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ExceptionCodeMessage {
-	INVALID_TOKEN_EXCEPTION("A001", "유요하지 않은 토큰입니다");
+	INVALID_TOKEN_EXCEPTION("A001", "유효하지 않은 토큰입니다");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
+++ b/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
@@ -1,0 +1,19 @@
+package com.teamddd.duckmap.common;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ExceptionCodeMessage {
+	INVALID_TOKEN_EXCEPTION("A001", "유요하지 않은 토큰입니다");
+
+	private final String code;
+	private final String message;
+
+	public String code() {
+		return code;
+	}
+
+	public String message() {
+		return message;
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/dto/ErrorResult.java
+++ b/src/main/java/com/teamddd/duckmap/dto/ErrorResult.java
@@ -1,0 +1,11 @@
+package com.teamddd.duckmap.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResult {
+	private String code;
+	private String message;
+}

--- a/src/main/java/com/teamddd/duckmap/exception/InvalidTokenException.java
+++ b/src/main/java/com/teamddd/duckmap/exception/InvalidTokenException.java
@@ -1,0 +1,26 @@
+package com.teamddd.duckmap.exception;
+
+import com.teamddd.duckmap.common.ExceptionCodeMessage;
+
+public class InvalidTokenException extends RuntimeException {
+	public InvalidTokenException() {
+		super(ExceptionCodeMessage.INVALID_TOKEN_EXCEPTION.message());
+	}
+
+	public InvalidTokenException(String message) {
+		super(message);
+	}
+
+	public InvalidTokenException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidTokenException(Throwable cause) {
+		super(cause);
+	}
+
+	public InvalidTokenException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/util/MemberUtils.java
+++ b/src/main/java/com/teamddd/duckmap/util/MemberUtils.java
@@ -1,0 +1,26 @@
+package com.teamddd.duckmap.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.teamddd.duckmap.config.security.SecurityUser;
+import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.exception.InvalidTokenException;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberUtils {
+
+	public static Member getAuthMember() throws InvalidTokenException {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		Object principal = auth.getPrincipal();
+		if (!(principal instanceof SecurityUser)) {
+			throw new InvalidTokenException();
+		}
+		return ((SecurityUser)principal).getUser();
+	}
+}


### PR DESCRIPTION
## Description

> 인증된 Member 조회하는 util 생성

## Changes

- MemberUtils 구현
- 인증된 Member가 없으면 InvalidTokenException 발생
- AuthAdvice에서 인증관련 ErrorResult response 반환
- ErrorResult로 exception response 생성
- enum ExceptionCodeMessage으로 error code, message 관리

## ETC
