### PR TITLE
Feat: #182 - 사용자 인증 불가 Exception 구현(InvalidMemberException)

### DIFF
--- a/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
+++ b/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
@@ -4,7 +4,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ExceptionCodeMessage {
-	INVALID_TOKEN_EXCEPTION("A001", "유효하지 않은 토큰입니다");
+	INVALID_TOKEN_EXCEPTION("A001", "유효하지 않은 토큰입니다"),
+	INVALID_MEMBER_EXCEPTION("A002", "유효하지 않은 이메일 혹은 비밀번호입니다");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/teamddd/duckmap/config/security/JwtProvider.java
+++ b/src/main/java/com/teamddd/duckmap/config/security/JwtProvider.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import com.teamddd.duckmap.entity.Role;
@@ -26,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class JwtProvider {
 	@Value("${jwt.secret}")
 	private String secretKey;
-	private final UserDetailsService userDetailsService;
+	private final SecurityUserDetailsService securityUserDetailsService;
 
 	// 객체 초기화, secret Key를 Base64로 인코딩
 	@PostConstruct
@@ -52,7 +51,7 @@ public class JwtProvider {
 
 	// JWT 토큰에서 인증 정보 조회
 	public Authentication getAuthentication(String token) {
-		UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserPK(token));
+		UserDetails userDetails = securityUserDetailsService.loadUserByUsername(this.getUserPK(token));
 		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
 	}
 

--- a/src/main/java/com/teamddd/duckmap/config/security/SecurityUserDetailsService.java
+++ b/src/main/java/com/teamddd/duckmap/config/security/SecurityUserDetailsService.java
@@ -1,14 +1,12 @@
 package com.teamddd.duckmap.config.security;
 
-import java.util.Optional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.exception.InvalidMemberException;
 import com.teamddd.duckmap.repository.MemberRepository;
 
 @Service
@@ -17,14 +15,9 @@ public class SecurityUserDetailsService implements UserDetailsService {
 	private MemberRepository memberRepository;
 
 	@Override
-	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		Optional<Member> optional = memberRepository.findByEmail(username);
-		if (optional.isEmpty()) {
-			throw new UsernameNotFoundException(username + " 사용자 찾을 수 없음");
-		} else {
-			Member member = optional.get();
-			return new SecurityUser(member);
-		}
-
+	public UserDetails loadUserByUsername(String username) {
+		Member member = memberRepository.findByEmail(username)
+			.orElseThrow(InvalidMemberException::new);
+		return new SecurityUser(member);
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/exception/InvalidMemberException.java
+++ b/src/main/java/com/teamddd/duckmap/exception/InvalidMemberException.java
@@ -1,0 +1,26 @@
+package com.teamddd.duckmap.exception;
+
+import com.teamddd.duckmap.common.ExceptionCodeMessage;
+
+public class InvalidMemberException extends RuntimeException {
+	public InvalidMemberException() {
+		super(ExceptionCodeMessage.INVALID_MEMBER_EXCEPTION.message());
+	}
+
+	public InvalidMemberException(String message) {
+		super(message);
+	}
+
+	public InvalidMemberException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidMemberException(Throwable cause) {
+		super(cause);
+	}
+
+	public InvalidMemberException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/service/MemberService.java
+++ b/src/main/java/com/teamddd/duckmap/service/MemberService.java
@@ -12,6 +12,7 @@ import com.teamddd.duckmap.dto.user.auth.LoginReq;
 import com.teamddd.duckmap.entity.LastSearchArtist;
 import com.teamddd.duckmap.entity.Member;
 import com.teamddd.duckmap.entity.Role;
+import com.teamddd.duckmap.exception.InvalidMemberException;
 import com.teamddd.duckmap.repository.LastSearchArtistRepository;
 import com.teamddd.duckmap.repository.MemberRepository;
 
@@ -37,9 +38,9 @@ public class MemberService {
 
 	public Member findOne(LoginReq loginUserRQ) {
 		Member member = memberRepository.findByEmail(loginUserRQ.getEmail())
-			.orElseThrow(() -> new IllegalArgumentException("가입 되지 않은 이메일입니다."));
+			.orElseThrow(InvalidMemberException::new);
 		if (!passwordEncoder.matches(loginUserRQ.getPassword(), member.getPassword())) {
-			throw new IllegalArgumentException("이메일 또는 비밀번호가 맞지 않습니다.");
+			throw new InvalidMemberException();
 		}
 		return member;
 	}


### PR DESCRIPTION
## Description

> 사용자 인증 불가 Exception 구현(InvalidMemberException)

## Changes

- INVALID_MEMBER_EXCEPTION("A002", "유효하지 않은 이메일 혹은 비밀번호입니다") 생성
- JwtProvider에서 토큰에서 인증 정보 조회시 userDetailsService 대신 custom한 securityUserDetailsService 사용
- SecurityUserDetailsService: Optional 사용 코드 개선

## ETC
