### PR TITLE
Feat: #173 - 관리자 권한만 artist type 저장 가능

### DIFF
--- a/src/main/java/com/teamddd/duckmap/config/security/SecurityRule.java
+++ b/src/main/java/com/teamddd/duckmap/config/security/SecurityRule.java
@@ -1,0 +1,9 @@
+package com.teamddd.duckmap.config.security;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SecurityRule {
+	public static final String HAS_ROLE_ADMIN = "hasRole('ADMIN')";
+}

--- a/src/main/java/com/teamddd/duckmap/controller/ArtistTypeController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ArtistTypeController.java
@@ -2,6 +2,7 @@ package com.teamddd.duckmap.controller;
 
 import java.util.List;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.teamddd.duckmap.config.security.SecurityRule;
 import com.teamddd.duckmap.dto.artist.ArtistTypeRes;
 import com.teamddd.duckmap.dto.artist.CreateArtistTypeReq;
 import com.teamddd.duckmap.dto.artist.CreateArtistTypeRes;
@@ -30,6 +32,7 @@ public class ArtistTypeController {
 
 	private final ArtistTypeService artistTypeService;
 
+	@PreAuthorize(SecurityRule.HAS_ROLE_ADMIN)
 	@Operation(summary = "아티스트 구분 등록")
 	@PostMapping
 	public CreateArtistTypeRes createArtistType(

--- a/src/test/java/com/teamddd/duckmap/controller/ArtistTypeControllerTest.java
+++ b/src/test/java/com/teamddd/duckmap/controller/ArtistTypeControllerTest.java
@@ -1,0 +1,71 @@
+package com.teamddd.duckmap.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamddd.duckmap.dto.artist.CreateArtistTypeReq;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ArtistTypeControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Nested
+	@DisplayName("아티스트 타입을 생성한다")
+	class CreateArtistType {
+		@DisplayName("관리자 계정은 아티스트 타입을 생성할 수 있다")
+		@Test
+		@WithMockUser(roles = "ADMIN")
+		void createArtistType1() throws Exception {
+			//given
+			CreateArtistTypeReq request = new CreateArtistTypeReq();
+			ReflectionTestUtils.setField(request, "type", "type1");
+
+			//when //then
+			mockMvc.perform(
+					post("/artists/types")
+						.content(objectMapper.writeValueAsString(request))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(print())
+				.andExpect(status().isOk());
+		}
+
+		@DisplayName("사용자 계정은 아티스트 타입을 생성할 수 없다")
+		@Test
+		@WithMockUser(roles = "USER")
+		void createArtistType2() throws Exception {
+			//given
+			CreateArtistTypeReq request = new CreateArtistTypeReq();
+			ReflectionTestUtils.setField(request, "type", "type1");
+
+			//when //then
+			mockMvc.perform(
+					post("/artists/types")
+						.content(objectMapper.writeValueAsString(request))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(print())
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.code").value("A004"))
+				.andExpect(jsonPath("$.message").value("권한이 없는 사용자입니다"));
+		}
+	}
+}


### PR DESCRIPTION
## Description

> artist type 생성 요청시 관리자 권한 확인 로직 추가

## Changes

- ArtistTypeController 아티스트 구분 등록 api에 @PreAuthorize 적용

## ETC
