### PR TITLE
artist 저장 기능 구현 및 api에 적용

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/ArtistController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ArtistController.java
@@ -22,6 +22,7 @@ import com.teamddd.duckmap.dto.artist.ArtistTypeRes;
 import com.teamddd.duckmap.dto.artist.CreateArtistReq;
 import com.teamddd.duckmap.dto.artist.CreateArtistRes;
 import com.teamddd.duckmap.dto.artist.UpdateArtistReq;
+import com.teamddd.duckmap.service.ArtistService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -32,12 +33,18 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @RequestMapping("/artists")
 public class ArtistController {
+
+	private final ArtistService artistService;
+
 	@Operation(summary = "아티스트 등록")
 	@PostMapping
 	public CreateArtistRes createArtist(
 		@Validated @RequestBody CreateArtistReq createArtistReq) {
+
+		Long artistId = artistService.createArtist(createArtistReq);
+
 		return CreateArtistRes.builder()
-			.id(1L)
+			.id(artistId)
 			.build();
 	}
 

--- a/src/main/java/com/teamddd/duckmap/controller/ArtistController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ArtistController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.teamddd.duckmap.config.security.SecurityRule;
 import com.teamddd.duckmap.dto.ImageRes;
 import com.teamddd.duckmap.dto.artist.ArtistRes;
 import com.teamddd.duckmap.dto.artist.ArtistSearchParam;
@@ -36,6 +38,7 @@ public class ArtistController {
 
 	private final ArtistService artistService;
 
+	@PreAuthorize(SecurityRule.HAS_ROLE_ADMIN)
 	@Operation(summary = "아티스트 등록")
 	@PostMapping
 	public CreateArtistRes createArtist(

--- a/src/main/java/com/teamddd/duckmap/dto/artist/CreateArtistReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/artist/CreateArtistReq.java
@@ -2,16 +2,19 @@ package com.teamddd.duckmap.dto.artist;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 
 import lombok.Getter;
 
 @Getter
 public class CreateArtistReq {
-	private Long groupId;
-	@NotBlank
-	private String name;
-	@NotNull
-	private String image;
-	@NotNull
+	@Positive
+	@NotNull(message = "아티스트 구분은 필수값입니다")
 	private Long artistTypeId;
+	@Positive
+	private Long groupId;
+	@NotBlank(message = "아티스트 이름은 필수값입니다")
+	private String name;
+	@NotBlank(message = "아티스트 사진은 필수값입니다")
+	private String image;
 }

--- a/src/main/java/com/teamddd/duckmap/service/ArtistService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ArtistService.java
@@ -1,0 +1,42 @@
+package com.teamddd.duckmap.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.dto.artist.CreateArtistReq;
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.ArtistType;
+import com.teamddd.duckmap.repository.ArtistRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ArtistService {
+
+	private final ArtistRepository artistRepository;
+
+	@Transactional
+	public Long createArtist(CreateArtistReq createArtistReq) {
+		Artist artist = Artist.builder()
+			.artistType(
+				ArtistType.builder()
+					.id(createArtistReq.getArtistTypeId())
+					.build()
+			)
+			.name(createArtistReq.getName())
+			.image(createArtistReq.getImage())
+			.group(
+				Artist.builder()
+					.id(createArtistReq.getGroupId())
+					.build()
+			).build();
+
+		artistRepository.save(artist);
+
+		return artist.getId();
+	}
+}

--- a/src/test/java/com/teamddd/duckmap/controller/ArtistControllerTest.java
+++ b/src/test/java/com/teamddd/duckmap/controller/ArtistControllerTest.java
@@ -1,0 +1,85 @@
+package com.teamddd.duckmap.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamddd.duckmap.dto.artist.CreateArtistReq;
+import com.teamddd.duckmap.service.ArtistService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ArtistControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@MockBean
+	private ArtistService artistService;
+
+	@DisplayName("아티스트를 등록한다")
+	@Nested
+	class CreateArtist {
+
+		@DisplayName("관리자 계정은 아티스트를 등록할 수 있다")
+		@Test
+		@WithMockUser(roles = "ADMIN")
+		void createArtist1() throws Exception {
+			//given
+			CreateArtistReq request = new CreateArtistReq();
+			ReflectionTestUtils.setField(request, "name", "artist1");
+			ReflectionTestUtils.setField(request, "image", "image");
+			ReflectionTestUtils.setField(request, "artistTypeId", 1L);
+
+			when(artistService.createArtist(any())).thenReturn(1L);
+
+			//when //then
+			mockMvc.perform(
+					post("/artists")
+						.content(objectMapper.writeValueAsString(request))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value("1"));
+		}
+
+		@DisplayName("사용자 계정은 아티스트를 등록할 수 없다")
+		@Test
+		@WithMockUser(roles = "USER")
+		void createArtist2() throws Exception {
+			//given
+			CreateArtistReq request = new CreateArtistReq();
+			ReflectionTestUtils.setField(request, "name", "artist1");
+			ReflectionTestUtils.setField(request, "image", "image");
+			ReflectionTestUtils.setField(request, "artistTypeId", 1L);
+
+			//when //then
+			mockMvc.perform(
+					post("/artists")
+						.content(objectMapper.writeValueAsString(request))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(print())
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.code").value("A004"))
+				.andExpect(jsonPath("$.message").value("권한이 없는 사용자입니다"));
+		}
+	}
+
+}

--- a/src/test/java/com/teamddd/duckmap/dto/artist/CreateArtistReqTest.java
+++ b/src/test/java/com/teamddd/duckmap/dto/artist/CreateArtistReqTest.java
@@ -1,0 +1,112 @@
+package com.teamddd.duckmap.dto.artist;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class CreateArtistReqTest {
+
+	static ValidatorFactory validatorFactory;
+	static Validator validator;
+
+	@BeforeAll
+	static void initialize() {
+		validatorFactory = Validation.buildDefaultValidatorFactory();
+		validator = validatorFactory.getValidator();
+	}
+
+	@AfterAll
+	static void destroy() {
+		validatorFactory.close();
+	}
+
+	@DisplayName("아티스트 구분은 필수값이다")
+	@Test
+	void notNullArtistTypeId() throws Exception {
+		//given
+		CreateArtistReq req = new CreateArtistReq();
+
+		//when
+		Set<ConstraintViolation<CreateArtistReq>> validate = validator.validateProperty(req, "artistTypeId");
+
+		//then
+		assertThat(validate).hasSize(1)
+			.extracting(ConstraintViolation::getMessage)
+			.containsOnly("아티스트 구분은 필수값입니다");
+	}
+
+	@DisplayName("아티스트 구분값은 양수이다")
+	@Test
+	void positiveArtistTypeId() throws Exception {
+		//given
+		CreateArtistReq req = new CreateArtistReq();
+		ReflectionTestUtils.setField(req, "artistTypeId", 0L);
+
+		//when
+		Set<ConstraintViolation<CreateArtistReq>> validate = validator.validateProperty(req, "artistTypeId");
+
+		//then
+		assertThat(validate).hasSize(1)
+			.extracting(ConstraintViolation::getMessage)
+			.containsOnly("0보다 커야 합니다");
+	}
+
+	@DisplayName("그룹값은 양수이다")
+	@Test
+	void positiveGroupId() throws Exception {
+		//given
+		CreateArtistReq req = new CreateArtistReq();
+		ReflectionTestUtils.setField(req, "groupId", 0L);
+
+		//when
+		Set<ConstraintViolation<CreateArtistReq>> validate = validator.validateProperty(req, "groupId");
+
+		//then
+		assertThat(validate).hasSize(1)
+			.extracting(ConstraintViolation::getMessage)
+			.containsOnly("0보다 커야 합니다");
+	}
+
+	@DisplayName("name은 필수값이다")
+	@Test
+	void notBlankName() throws Exception {
+		//given
+		CreateArtistReq req = new CreateArtistReq();
+		ReflectionTestUtils.setField(req, "name", " ");
+
+		//when
+		Set<ConstraintViolation<CreateArtistReq>> validate = validator.validateProperty(req, "name");
+
+		//then
+		assertThat(validate).hasSize(1)
+			.extracting(ConstraintViolation::getMessage)
+			.containsOnly("아티스트 이름은 필수값입니다");
+	}
+
+	@DisplayName("image는 필수값이다")
+	@Test
+	void notBlankImage() throws Exception {
+		//given
+		CreateArtistReq req = new CreateArtistReq();
+		ReflectionTestUtils.setField(req, "image", " ");
+
+		//when
+		Set<ConstraintViolation<CreateArtistReq>> validate = validator.validateProperty(req, "image");
+
+		//then
+		assertThat(validate).hasSize(1)
+			.extracting(ConstraintViolation::getMessage)
+			.containsOnly("아티스트 사진은 필수값입니다");
+	}
+}

--- a/src/test/java/com/teamddd/duckmap/service/ArtistServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/ArtistServiceTest.java
@@ -1,0 +1,61 @@
+package com.teamddd.duckmap.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.dto.artist.CreateArtistReq;
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.ArtistType;
+import com.teamddd.duckmap.repository.ArtistRepository;
+
+@Transactional
+@SpringBootTest
+class ArtistServiceTest {
+
+	@Autowired
+	ArtistService artistService;
+	@Autowired
+	ArtistRepository artistRepository;
+	@Autowired
+	EntityManager em;
+
+	@DisplayName("아티스트를 등록한다")
+	@Test
+	void createArtist() throws Exception {
+		//given
+		ArtistType artistType = createArtistType();
+		em.persist(artistType);
+
+		CreateArtistReq request = new CreateArtistReq();
+		ReflectionTestUtils.setField(request, "name", "artist1");
+		ReflectionTestUtils.setField(request, "image", "filename.png");
+		ReflectionTestUtils.setField(request, "artistTypeId", artistType.getId());
+
+		//when
+		Long artistId = artistService.createArtist(request);
+
+		//then
+		assertThat(artistId).isNotNull();
+
+		Optional<Artist> findArtist = artistRepository.findById(artistId);
+		assertThat(findArtist).isNotEmpty();
+		assertThat(findArtist.get()).extracting("id", "name")
+			.contains(1L, "artist1");
+	}
+
+	ArtistType createArtistType() {
+		return ArtistType.builder()
+			.type("artistType")
+			.build();
+	}
+}


### PR DESCRIPTION
## Description

> artist 저장 기능 구현 및 api에 적용

## Changes

- artist 저장 기능 구현
- api에 관리자 권한만 접근 가능하게 변경
- api request validation message 추가

## ETC
