### PR TITLE
artist 저장 기능 api에 적용 및 CreateArtistReq validation message 작성

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/ArtistController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ArtistController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.teamddd.duckmap.config.security.SecurityRule;
 import com.teamddd.duckmap.dto.ImageRes;
 import com.teamddd.duckmap.dto.artist.ArtistRes;
 import com.teamddd.duckmap.dto.artist.ArtistSearchParam;
@@ -22,6 +24,7 @@ import com.teamddd.duckmap.dto.artist.ArtistTypeRes;
 import com.teamddd.duckmap.dto.artist.CreateArtistReq;
 import com.teamddd.duckmap.dto.artist.CreateArtistRes;
 import com.teamddd.duckmap.dto.artist.UpdateArtistReq;
+import com.teamddd.duckmap.service.ArtistService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -32,12 +35,19 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @RequestMapping("/artists")
 public class ArtistController {
+
+	private final ArtistService artistService;
+
+	@PreAuthorize(SecurityRule.HAS_ROLE_ADMIN)
 	@Operation(summary = "아티스트 등록")
 	@PostMapping
 	public CreateArtistRes createArtist(
 		@Validated @RequestBody CreateArtistReq createArtistReq) {
+
+		Long artistId = artistService.createArtist(createArtistReq);
+
 		return CreateArtistRes.builder()
-			.id(1L)
+			.id(artistId)
 			.build();
 	}
 

--- a/src/main/java/com/teamddd/duckmap/dto/artist/CreateArtistReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/artist/CreateArtistReq.java
@@ -7,11 +7,11 @@ import lombok.Getter;
 
 @Getter
 public class CreateArtistReq {
-	private Long groupId;
-	@NotBlank
-	private String name;
-	@NotNull
-	private String image;
-	@NotNull
+	@NotNull(message = "아티스트 구분은 필수값입니다")
 	private Long artistTypeId;
+	private Long groupId;
+	@NotBlank(message = "아티스트 이름은 필수값입니다")
+	private String name;
+	@NotBlank(message = "아티스트 사진은 필수값입니다")
+	private String image;
 }

--- a/src/test/java/com/teamddd/duckmap/controller/ArtistControllerTest.java
+++ b/src/test/java/com/teamddd/duckmap/controller/ArtistControllerTest.java
@@ -1,0 +1,85 @@
+package com.teamddd.duckmap.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamddd.duckmap.dto.artist.CreateArtistReq;
+import com.teamddd.duckmap.service.ArtistService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ArtistControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@MockBean
+	private ArtistService artistService;
+
+	@DisplayName("아티스트를 등록한다")
+	@Nested
+	class CreateArtist {
+
+		@DisplayName("관리자 계정은 아티스트를 등록할 수 있다")
+		@Test
+		@WithMockUser(roles = "ADMIN")
+		void createArtist1() throws Exception {
+			//given
+			CreateArtistReq request = new CreateArtistReq();
+			ReflectionTestUtils.setField(request, "name", "artist1");
+			ReflectionTestUtils.setField(request, "image", "image");
+			ReflectionTestUtils.setField(request, "artistTypeId", 1L);
+
+			when(artistService.createArtist(any())).thenReturn(1L);
+
+			//when //then
+			mockMvc.perform(
+					post("/artists")
+						.content(objectMapper.writeValueAsString(request))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value("1"));
+		}
+
+		@DisplayName("사용자 계정은 아티스트를 등록할 수 없다")
+		@Test
+		@WithMockUser(roles = "USER")
+		void createArtist2() throws Exception {
+			//given
+			CreateArtistReq request = new CreateArtistReq();
+			ReflectionTestUtils.setField(request, "name", "artist1");
+			ReflectionTestUtils.setField(request, "image", "image");
+			ReflectionTestUtils.setField(request, "artistTypeId", 1L);
+
+			//when //then
+			mockMvc.perform(
+					post("/artists")
+						.content(objectMapper.writeValueAsString(request))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(print())
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.code").value("A004"))
+				.andExpect(jsonPath("$.message").value("권한이 없는 사용자입니다"));
+		}
+	}
+
+}

--- a/src/test/java/com/teamddd/duckmap/dto/artist/CreateArtistReqTest.java
+++ b/src/test/java/com/teamddd/duckmap/dto/artist/CreateArtistReqTest.java
@@ -1,0 +1,80 @@
+package com.teamddd.duckmap.dto.artist;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class CreateArtistReqTest {
+
+	static ValidatorFactory validatorFactory;
+	static Validator validator;
+
+	@BeforeAll
+	static void initialize() {
+		validatorFactory = Validation.buildDefaultValidatorFactory();
+		validator = validatorFactory.getValidator();
+	}
+
+	@AfterAll
+	static void destroy() {
+		validatorFactory.close();
+	}
+
+	@DisplayName("아티스트 구분은 필수값이다")
+	@Test
+	void notNullArtistTypeId() throws Exception {
+		//given
+		CreateArtistReq req = new CreateArtistReq();
+
+		//when
+		Set<ConstraintViolation<CreateArtistReq>> validate = validator.validateProperty(req, "artistTypeId");
+
+		//then
+		assertThat(validate).hasSize(1)
+			.extracting(ConstraintViolation::getMessage)
+			.containsOnly("아티스트 구분은 필수값입니다");
+	}
+
+	@DisplayName("name은 필수값이다")
+	@Test
+	void notBlankName() throws Exception {
+		//given
+		CreateArtistReq req = new CreateArtistReq();
+		ReflectionTestUtils.setField(req, "name", " ");
+
+		//when
+		Set<ConstraintViolation<CreateArtistReq>> validate = validator.validateProperty(req, "name");
+
+		//then
+		assertThat(validate).hasSize(1)
+			.extracting(ConstraintViolation::getMessage)
+			.containsOnly("아티스트 이름은 필수값입니다");
+	}
+
+	@DisplayName("image는 필수값이다")
+	@Test
+	void notBlankImage() throws Exception {
+		//given
+		CreateArtistReq req = new CreateArtistReq();
+		ReflectionTestUtils.setField(req, "image", " ");
+
+		//when
+		Set<ConstraintViolation<CreateArtistReq>> validate = validator.validateProperty(req, "image");
+
+		//then
+		assertThat(validate).hasSize(1)
+			.extracting(ConstraintViolation::getMessage)
+			.containsOnly("아티스트 사진은 필수값입니다");
+	}
+}


### PR DESCRIPTION
## Description

> artist 저장 api 기능 구현, 리팩토링

## Changes

- artist 저장 기능 api에 적용
- CreateArtistReq validation message 작성

## ETC
