### PR TITLE
Feat: #233 - 회원 탈퇴시 비밀번호 확인 로직 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/MemberController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/MemberController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.teamddd.duckmap.dto.user.CreateMemberReq;
 import com.teamddd.duckmap.dto.user.CreateMemberRes;
+import com.teamddd.duckmap.dto.user.DeleteMemberReq;
 import com.teamddd.duckmap.dto.user.MemberRes;
 import com.teamddd.duckmap.dto.user.UpdateMemberReq;
 import com.teamddd.duckmap.dto.user.UpdatePasswordReq;
@@ -60,9 +61,11 @@ public class MemberController {
 
 	@Operation(summary = "회원 탈퇴")
 	@DeleteMapping("/me")
-	public void deleteMember(@RequestHeader("Authorization") String requestAccessToken) {
+	public void deleteMember(@RequestHeader("Authorization") String requestAccessToken,
+		@Validated @RequestBody DeleteMemberReq deleteMemberReq) {
+		Long id = memberService.validatePassword(deleteMemberReq.getPassword());
 		authService.logout(requestAccessToken);
-		memberService.deleteMember();
+		memberService.deleteMember(id);
 	}
 
 }

--- a/src/main/java/com/teamddd/duckmap/dto/user/DeleteMemberReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/DeleteMemberReq.java
@@ -1,0 +1,11 @@
+package com.teamddd.duckmap.dto.user;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteMemberReq {
+	@NotBlank
+	private String password;
+}

--- a/src/main/java/com/teamddd/duckmap/service/MemberService.java
+++ b/src/main/java/com/teamddd/duckmap/service/MemberService.java
@@ -75,10 +75,16 @@ public class MemberService {
 	}
 
 	@Transactional
-	public void deleteMember() {
-		Member member = memberRepository.findByEmail(MemberUtils.getAuthMember().getUsername())
-			.orElseThrow(InvalidMemberException::new);
-		memberRepository.delete(member);
+	public void deleteMember(Long id) {
+		memberRepository.deleteById(id);
 	}
 
+	public Long validatePassword(String password) {
+		Member member = memberRepository.findByEmail(MemberUtils.getAuthMember().getUsername())
+			.orElseThrow(InvalidMemberException::new);
+		if (!passwordEncoder.matches(password, member.getPassword())) {
+			throw new InvalidPasswordException();
+		}
+		return member.getId();
+	}
 }


### PR DESCRIPTION
## Description

> 회원 탈퇴시 비밀번호 확인 로직 구현

## Changes

- DeleteMemberReq 생성
- 회원 탈퇴 API에 비밀번호 확인하는 validatePassword()를 호출하여 비밀번호 확인을 먼저 한다.

## ETC
