### PR TITLE
토큰 검증 및 재발급 구현 완료

### DIFF
--- a/src/main/java/com/teamddd/duckmap/config/security/JwtProvider.java
+++ b/src/main/java/com/teamddd/duckmap/config/security/JwtProvider.java
@@ -104,9 +104,6 @@ public class JwtProvider {
 	// 토큰의 유효성 + 만료일자 확인
 	public boolean validateRefreshToken(String refreshToken) {
 		try {
-			if (redisService.getValues(refreshToken).equals("delete")) { // 회원 탈퇴했을 경우
-				return false;
-			}
 			Jwts.parserBuilder()
 				.setSigningKey(signingKey)
 				.build()

--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.teamddd.duckmap.controller;
 
-import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -35,14 +34,8 @@ public class AuthController {
 
 		// User 등록 및 Refresh Token 저장
 		TokenDto tokenDto = authService.login(loginUserRQ);
-		// RT 저장
-		HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
-			.maxAge(COOKIE_EXPIRATION)
-			.httpOnly(true)
-			.secure(true)
-			.build();
+
 		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, httpCookie.toString())
 			// AT 저장
 			.header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenDto.getAccessToken())
 			.build();


### PR DESCRIPTION
## Description

> access 토큰과 refresh 토큰의 검증 및 재발급 기능 구현 완료

## Changes

- 로그인시 client에 access token만 반환한다.
- 보안을 위해 refresh token은 redis에만 저장한다.
- /auth/validate 는 access token이 유효한지 확인한다. (유효할시 200, 유효하지 않을시 401)
- /auth/reissue 는 access token이 유효할때만 access token과 refresh token을 재발급한다.
  - 이때 refresh token은 redis에서 찾아온다. 

## ETC
