### PR TITLE
#254 Refresh 토큰 관련 리팩토링

### DIFF
--- a/src/main/java/com/teamddd/duckmap/config/security/JwtProvider.java
+++ b/src/main/java/com/teamddd/duckmap/config/security/JwtProvider.java
@@ -70,6 +70,7 @@ public class JwtProvider {
 			.setHeaderParam("alg", "HS512")
 			.setExpiration(new Date(now + REFRESH_TOKEN_VALID_TIME))
 			.setSubject("refresh-token")
+			.claim(EMAIL_KEY, email)
 			.signWith(signingKey)
 			.compact();
 
@@ -94,6 +95,18 @@ public class JwtProvider {
 	public Authentication getAuthentication(String token) {
 		String email = getClaims(token).get(EMAIL_KEY).toString();
 		UserDetailsImpl userDetails = userDetailsService.loadUserByUsername(email);
+		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+	}
+
+	/**
+	 * Refresh 토큰으로부터 클레임을 만들고, 이를 통해 User 객체를 생성하여 Authentication 객체를 반환
+	 * @param refresh_token
+	 * @return
+	 */
+	public Authentication getAuthenticationByRefreshToken(String refresh_token) {
+		String userPrincipal = getClaims(refresh_token).get(EMAIL_KEY).toString();
+		UserDetailsImpl userDetails = userDetailsService.loadUserByUsername(userPrincipal);
+
 		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
 	}
 

--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.teamddd.duckmap.controller;
 
+import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -34,7 +35,14 @@ public class AuthController {
 		// User 등록 및 Refresh Token 저장
 		TokenDto tokenDto = authService.login(loginUserRQ);
 
+		// RT 저장
+		HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
+			.maxAge(COOKIE_EXPIRATION)
+			.httpOnly(true)
+			.secure(true)
+			.build();
 		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, httpCookie.toString())
 			// AT 저장
 			.header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenDto.getAccessToken())
 			.build();

--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -26,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/auth")
 public class AuthController {
 	private final AuthService authService;
-	private static final long COOKIE_EXPIRATION = 7776000;
+	private static final long COOKIE_EXPIRATION = 604800;
 
 	@Operation(summary = "로그인")
 	@PostMapping("/login")
@@ -59,20 +60,33 @@ public class AuthController {
 
 	// 토큰 재발급
 	@PostMapping("/reissue")
-	public ResponseEntity<?> reissue(@RequestHeader("Authorization") String requestAccessToken) {
-		TokenDto reissuedTokenDto = authService.reissue(requestAccessToken);
+	public ResponseEntity<?> reissue(@CookieValue(name = "refresh-token") String requestRefreshToken) {
+		log.info(requestRefreshToken);
+		TokenDto reissuedTokenDto = authService.reissue(requestRefreshToken);
 
 		if (reissuedTokenDto != null) { // 토큰 재발급 성공
+			// RT 저장
+			ResponseCookie responseCookie = ResponseCookie.from("refresh-token", reissuedTokenDto.getRefreshToken())
+				.maxAge(COOKIE_EXPIRATION)
+				.httpOnly(true)
+				.secure(true)
+				.build();
 			return ResponseEntity
 				.status(HttpStatus.OK)
+				.header(HttpHeaders.SET_COOKIE, responseCookie.toString())
 				// AT 저장
 				.header(HttpHeaders.AUTHORIZATION, "Bearer " + reissuedTokenDto.getAccessToken())
 				.build();
 
 		} else { // Refresh Token 탈취 가능성
-			// 재로그인 유도
+			// Cookie 삭제 후 재로그인 유도
+			ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")
+				.maxAge(0)
+				.path("/")
+				.build();
 			return ResponseEntity
 				.status(HttpStatus.UNAUTHORIZED)
+				.header(HttpHeaders.SET_COOKIE, responseCookie.toString())
 				.build();
 		}
 	}

--- a/src/main/java/com/teamddd/duckmap/service/AuthService.java
+++ b/src/main/java/com/teamddd/duckmap/service/AuthService.java
@@ -61,13 +61,13 @@ public class AuthService {
 		return jwtProvider.validateAccessTokenOnlyExpired(requestAccessToken); // true = 재발급
 	}
 
-	// 토큰 재발급: validate 메서드가 true 반환할 때만 사용 -> AT, RT 재발급
+	// 토큰 재발급: AT, RT 재발급
 	@Transactional
-	public TokenDto reissue(String requestAccessTokenInHeader) {
-		String requestAccessToken = resolveToken(requestAccessTokenInHeader);
+	public TokenDto reissue(String requestRefreshTokenInHeader) {
 
-		Authentication authentication = jwtProvider.getAuthentication(requestAccessToken);
-		String principal = getPrincipal(requestAccessToken);
+		Authentication authentication = jwtProvider.getAuthenticationByRefreshToken(requestRefreshTokenInHeader);
+		String principal = getPrincipalByRefreshToken(requestRefreshTokenInHeader);
+
 		String refreshTokenInRedis = redisService.getValues("RT(" + SERVER + "):" + principal);
 		if (refreshTokenInRedis == null) { // Redis에 저장되어 있는 RT가 없을 경우
 			return null; // -> 재로그인 요청
@@ -106,6 +106,11 @@ public class AuthService {
 	// AT로부터 principal 추출
 	public String getPrincipal(String requestAccessToken) {
 		return jwtProvider.getAuthentication(requestAccessToken).getName();
+	}
+
+	// RT로부터 principal 추출
+	public String getPrincipalByRefreshToken(String requestRefreshToken) {
+		return jwtProvider.getAuthenticationByRefreshToken(requestRefreshToken).getName();
 	}
 
 	// "Bearer {AT}"에서 {AT} 추출


### PR DESCRIPTION
## Description

>Front 단에서 Refresh 토큰 사용 편의를 위한 코드 리팩토링

## Changes

- 로그인시 RT를 쿠키에 넣어 반환 하도록 수정
- 재발급시 RT만 받아서 AT, RT를 재발급 하도록 수정
- 쿠키 유효시간 9일에서 7일로 변경
- AuthController
- AuthService
- JwtProvider

## ETC
