### PR TITLE
Feat: #259 - 인증번호 생성 및 이메일 전송 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     //swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -116,7 +116,7 @@ public class AuthController {
 	@Operation(summary = "인증번호 생성 및 이메일 전송")
 	@PostMapping("/send-verification")
 	public String sendVerification(@Validated @RequestBody VerificationReq verificationReq) {
-		memberService.getMemberByEmail(verificationReq.getEmail());
+		memberService.checkMemberByEmail(verificationReq.getEmail());
 		return mailService.sendVerification(verificationReq.getEmail());
 	}
 

--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -15,7 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.teamddd.duckmap.config.security.TokenDto;
 import com.teamddd.duckmap.dto.user.auth.LoginReq;
+import com.teamddd.duckmap.dto.user.auth.VerificationReq;
 import com.teamddd.duckmap.service.AuthService;
+import com.teamddd.duckmap.service.MemberService;
+import com.teamddd.duckmap.service.SendMailService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/auth")
 public class AuthController {
 	private final AuthService authService;
+	private final MemberService memberService;
+	private final SendMailService mailService;
 	private static final long COOKIE_EXPIRATION = 604800;
 
 	@Operation(summary = "로그인")
@@ -105,6 +110,15 @@ public class AuthController {
 			.status(HttpStatus.OK)
 			.header(HttpHeaders.SET_COOKIE, responseCookie.toString())
 			.build();
+	}
+
+	//인증번호 생성 및 이메일 전송
+	@Operation(summary = "인증번호 생성 및 이메일 전송")
+	@PostMapping("/send-verification")
+	public String sendVerification(@Validated @RequestBody VerificationReq verificationReq) {
+		memberService.getMemberByEmail(verificationReq.getEmail());
+		String verifyCode = mailService.sendVerification(verificationReq.getEmail());
+		return verifyCode;
 	}
 
 }

--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -117,8 +117,7 @@ public class AuthController {
 	@PostMapping("/send-verification")
 	public String sendVerification(@Validated @RequestBody VerificationReq verificationReq) {
 		memberService.getMemberByEmail(verificationReq.getEmail());
-		String verifyCode = mailService.sendVerification(verificationReq.getEmail());
-		return verifyCode;
+		return mailService.sendVerification(verificationReq.getEmail());
 	}
 
 }

--- a/src/main/java/com/teamddd/duckmap/dto/user/auth/VerificationReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/auth/VerificationReq.java
@@ -1,0 +1,13 @@
+package com.teamddd.duckmap.dto.user.auth;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import lombok.Getter;
+
+@Getter
+public class VerificationReq {
+	@NotBlank
+	@Email
+	private String email;
+}

--- a/src/main/java/com/teamddd/duckmap/service/MemberService.java
+++ b/src/main/java/com/teamddd/duckmap/service/MemberService.java
@@ -50,6 +50,10 @@ public class MemberService {
 		});
 	}
 
+	public void getMemberByEmail(String email) {
+		memberRepository.findByEmail(email).orElseThrow(InvalidMemberException::new);
+	}
+
 	public MemberRes getMyInfoBySecurity() {
 		return memberRepository.findByEmail(MemberUtils.getAuthMember().getUsername())
 			.map(MemberRes::of)

--- a/src/main/java/com/teamddd/duckmap/service/MemberService.java
+++ b/src/main/java/com/teamddd/duckmap/service/MemberService.java
@@ -50,7 +50,7 @@ public class MemberService {
 		});
 	}
 
-	public void getMemberByEmail(String email) {
+	public void checkMemberByEmail(String email) {
 		memberRepository.findByEmail(email).orElseThrow(InvalidMemberException::new);
 	}
 

--- a/src/main/java/com/teamddd/duckmap/service/SendMailService.java
+++ b/src/main/java/com/teamddd/duckmap/service/SendMailService.java
@@ -1,0 +1,64 @@
+package com.teamddd.duckmap.service;
+
+import java.util.Random;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SendMailService {
+
+	@Value("${spring.mail.username}")
+	private String fromEmail;
+	@Autowired
+	JavaMailSender mailSender;
+
+	public int makeRandomNumber() {
+		Random r = new Random();
+		return r.nextInt(999999); // 랜덤 6자리 난수설정
+	}
+
+	public String sendVerification(String email) {
+		int verifyCode = makeRandomNumber();
+		String setFrom = fromEmail;
+		String toMail = email;
+		String title = "비밀번호 찾기 인증번호 입니다."; // 이메일 제목
+		String content =
+			"대동덕지도" +    //html 형식으로 작성
+				"<br><br>" +
+				"인증 번호는 " + verifyCode + "입니다." +
+				"<br>" +
+				"해당 인증번호를 인증번호 확인란에 기입하여 주세요."; //이메일 내용 삽입
+		mailSend(setFrom, toMail, title, content);
+		return Integer.toString(verifyCode);
+	}
+
+	//이메일 전송 메소드
+	public void mailSend(String setFrom, String toMail, String title, String content) {
+		MimeMessage message = mailSender.createMimeMessage();
+		// true 매개값을 전달하면 multipart 형식의 메세지 전달이 가능.문자 인코딩 설정도 가능하다.
+		try {
+			MimeMessageHelper helper = new MimeMessageHelper(message, true, "utf-8");
+			helper.setFrom(setFrom);
+			helper.setTo(toMail);
+			helper.setSubject(title);
+			// true 전달 > html 형식으로 전송 , 작성하지 않으면 단순 텍스트로 전달.
+			helper.setText(content, true);
+			mailSender.send(message);
+		} catch (MessagingException e) {
+			e.printStackTrace();
+		}
+
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/service/SendMailService.java
+++ b/src/main/java/com/teamddd/duckmap/service/SendMailService.java
@@ -25,8 +25,8 @@ public class SendMailService {
 	JavaMailSender mailSender;
 
 	public int makeRandomNumber() {
-		Random r = new Random();
-		return r.nextInt(999999); // 랜덤 6자리 난수설정
+		Random random = new Random();
+		return random.nextInt(999999); // 랜덤 6자리 난수설정
 	}
 
 	public String sendVerification(String email) {
@@ -34,12 +34,9 @@ public class SendMailService {
 		String setFrom = fromEmail;
 		String toMail = email;
 		String title = "비밀번호 찾기 인증번호 입니다."; // 이메일 제목
-		String content =
-			"대동덕지도" +    //html 형식으로 작성
-				"<br><br>" +
-				"인증 번호는 " + verifyCode + "입니다." +
-				"<br>" +
-				"해당 인증번호를 인증번호 확인란에 기입하여 주세요."; //이메일 내용 삽입
+		String content = "대동덕지도" //html 형식으로 작성
+			+ "<br><br>" + "인증 번호는 " + verifyCode + "입니다." + "<br>"
+			+ "해당 인증번호를 인증번호 확인란에 기입하여 주세요."; //이메일 내용 삽입
 		mailSend(setFrom, toMail, title, content);
 		return Integer.toString(verifyCode);
 	}

--- a/src/main/java/com/teamddd/duckmap/service/SendMailService.java
+++ b/src/main/java/com/teamddd/duckmap/service/SendMailService.java
@@ -32,12 +32,11 @@ public class SendMailService {
 	public String sendVerification(String email) {
 		int verifyCode = makeRandomNumber();
 		String setFrom = fromEmail;
-		String toMail = email;
 		String title = "비밀번호 찾기 인증번호 입니다."; // 이메일 제목
 		String content = "대동덕지도" //html 형식으로 작성
 			+ "<br><br>" + "인증 번호는 " + verifyCode + "입니다." + "<br>"
 			+ "해당 인증번호를 인증번호 확인란에 기입하여 주세요."; //이메일 내용 삽입
-		mailSend(setFrom, toMail, title, content);
+		mailSend(setFrom, email, title, content);
 		return Integer.toString(verifyCode);
 	}
 


### PR DESCRIPTION
## Description

> 인증번호 생성 및 이메일 전송 구현

## Changes

- build.gradle에 spring-boot-starter-mail 추가
- SendMailService
  - mailSend 구현
  - sendVerification 구현
  - makeRandomNumber 구현
- VerificationReq 생성
- AuthController의 sendVerification() 구현

## ETC
- application.yml에 SMTP 설정 추가 필요함 (디스코드로 전달 예정)
