### PR TITLE
비밀번호 재설정 API 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/advice/AuthAdvice.java
+++ b/src/main/java/com/teamddd/duckmap/advice/AuthAdvice.java
@@ -65,7 +65,7 @@ public class AuthAdvice {
 			.build();
 	}
 
-	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler
 	public ErrorResult invalidUuidException(InvalidUuidException ex) {
 		return ErrorResult.builder()

--- a/src/main/java/com/teamddd/duckmap/advice/AuthAdvice.java
+++ b/src/main/java/com/teamddd/duckmap/advice/AuthAdvice.java
@@ -12,6 +12,7 @@ import com.teamddd.duckmap.dto.ErrorResult;
 import com.teamddd.duckmap.exception.InvalidMemberException;
 import com.teamddd.duckmap.exception.InvalidPasswordException;
 import com.teamddd.duckmap.exception.InvalidTokenException;
+import com.teamddd.duckmap.exception.InvalidUuidException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -64,4 +65,12 @@ public class AuthAdvice {
 			.build();
 	}
 
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	@ExceptionHandler
+	public ErrorResult invalidUuidException(InvalidUuidException ex) {
+		return ErrorResult.builder()
+			.code(ExceptionCodeMessage.INVALID_UUID_EXCEPTION.code())
+			.message(ex.getMessage())
+			.build();
+	}
 }

--- a/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
+++ b/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
@@ -10,7 +10,7 @@ public enum ExceptionCodeMessage {
 	AUTHENTICATION_EXCEPTION("A003", "잘못된 인증입니다"),
 	ACCESS_DENIED_EXCEPTION("A004", "권한이 없는 사용자입니다"),
 	INVALID_PASSWORD_EXCEPTION("A005", "비밀번호가 맞지 않습니다"),
-	INVALID_UUID_EXCEPTION("A006", "유효하지 UUID 입니다"),
+	INVALID_UUID_EXCEPTION("A006", "유효하지 않은 UUID 입니다"),
 
 	/* Member */
 	DUPLICATE_EMAIL_EXCEPTION("M001", "이미 사용중인 이메일입니다"),

--- a/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
+++ b/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
@@ -4,11 +4,15 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ExceptionCodeMessage {
+	/* Auth */
 	INVALID_TOKEN_EXCEPTION("A001", "유효하지 않은 토큰입니다"),
 	INVALID_MEMBER_EXCEPTION("A002", "유효하지 않은 이메일 혹은 비밀번호입니다"),
 	AUTHENTICATION_EXCEPTION("A003", "잘못된 인증입니다"),
 	ACCESS_DENIED_EXCEPTION("A004", "권한이 없는 사용자입니다"),
 	INVALID_PASSWORD_EXCEPTION("A005", "비밀번호가 맞지 않습니다"),
+	INVALID_UUID_EXCEPTION("A006", "유효하지 UUID 입니다"),
+
+	/* Member */
 	DUPLICATE_EMAIL_EXCEPTION("M001", "이미 사용중인 이메일입니다"),
 	DUPLICATE_USERNAME_EXCEPTION("M002", "이미 사용중인 닉네임입니다"),
 

--- a/src/main/java/com/teamddd/duckmap/controller/MemberController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/MemberController.java
@@ -70,7 +70,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = "비밀번호 재설정", description = "비밀번호를 새로 재설정")
-	@PatchMapping("/reset-password")
+	@PatchMapping("/reset-password/{id}")
 	public void resetPassword(@Validated @RequestBody ResetPasswordReq resetPasswordReq) {
 		memberService.resetPassword(resetPasswordReq.getUuid(), resetPasswordReq.getNewPassword());
 	}

--- a/src/main/java/com/teamddd/duckmap/controller/MemberController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/MemberController.java
@@ -15,6 +15,7 @@ import com.teamddd.duckmap.dto.user.CreateMemberReq;
 import com.teamddd.duckmap.dto.user.CreateMemberRes;
 import com.teamddd.duckmap.dto.user.DeleteMemberReq;
 import com.teamddd.duckmap.dto.user.MemberRes;
+import com.teamddd.duckmap.dto.user.ResetPasswordReq;
 import com.teamddd.duckmap.dto.user.UpdateMemberReq;
 import com.teamddd.duckmap.dto.user.UpdatePasswordReq;
 import com.teamddd.duckmap.service.AuthService;
@@ -66,6 +67,12 @@ public class MemberController {
 		Long id = memberService.validatePassword(deleteMemberReq.getPassword());
 		authService.logout(requestAccessToken);
 		memberService.deleteMember(id);
+	}
+
+	@Operation(summary = "비밀번호 재설정", description = "비밀번호를 새로 재설정")
+	@PatchMapping("/reset-password")
+	public void resetPassword(@Validated @RequestBody ResetPasswordReq resetPasswordReq) {
+		memberService.resetPassword(resetPasswordReq.getUuid(), resetPasswordReq.getNewPassword());
 	}
 
 }

--- a/src/main/java/com/teamddd/duckmap/dto/user/ResetPasswordReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/ResetPasswordReq.java
@@ -1,0 +1,16 @@
+package com.teamddd.duckmap.dto.user;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import lombok.Getter;
+
+@Getter
+public class ResetPasswordReq {
+	@NotBlank
+	private String uuid;
+	@NotBlank
+	@Pattern(regexp = "(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*]).{8,16}",
+		message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+	private String newPassword;
+}

--- a/src/main/java/com/teamddd/duckmap/exception/InvalidUuidException.java
+++ b/src/main/java/com/teamddd/duckmap/exception/InvalidUuidException.java
@@ -1,0 +1,26 @@
+package com.teamddd.duckmap.exception;
+
+import com.teamddd.duckmap.common.ExceptionCodeMessage;
+
+public class InvalidUuidException extends RuntimeException {
+	public InvalidUuidException() {
+		super(ExceptionCodeMessage.INVALID_UUID_EXCEPTION.message());
+	}
+
+	public InvalidUuidException(String message) {
+		super(message);
+	}
+
+	public InvalidUuidException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidUuidException(Throwable cause) {
+		super(cause);
+	}
+
+	public InvalidUuidException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/service/MemberService.java
+++ b/src/main/java/com/teamddd/duckmap/service/MemberService.java
@@ -12,6 +12,7 @@ import com.teamddd.duckmap.exception.DuplicateEmailException;
 import com.teamddd.duckmap.exception.DuplicateUsernameException;
 import com.teamddd.duckmap.exception.InvalidMemberException;
 import com.teamddd.duckmap.exception.InvalidPasswordException;
+import com.teamddd.duckmap.exception.InvalidUuidException;
 import com.teamddd.duckmap.repository.MemberRepository;
 import com.teamddd.duckmap.util.MemberUtils;
 
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final RedisService redisService;
 
 	@Transactional
 	public Long join(CreateMemberReq createMemberReq) {
@@ -91,4 +93,24 @@ public class MemberService {
 		}
 		return member.getId();
 	}
+
+	@Transactional
+	public void resetPassword(String uuid, String newPassword) {
+		//redis에 uuid가 있는지 확인, 없으면 error
+		String email = redisService.getValues(uuid);
+		if (email == null) {
+			throw new InvalidUuidException();
+		}
+
+		//redis에서 uuid로 email을 찾아온다.
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(InvalidMemberException::new);
+
+		//비밀번호 재설정
+		member.updatePassword(passwordEncoder.encode((newPassword)));
+
+		//비밀번호 업데이트 후 redis에서 uuid를 지운다.
+		redisService.deleteValues(uuid);
+	}
+
 }


### PR DESCRIPTION
## Description

> 비밀번호 재설정 API 구현

## Changes

- resetPassword 서비스 구현
  - redis 에서 uuid가 유효한지 확인한다.
  - redis에서 uuid로 email을 찾아온다.
  - 비밀번호 재설정
  - 비밀번호 업데이트 후 redis에서 uuid를 지운다.
- InvalidUuidException 생성

## ETC
