### PR TITLE
#249 비밀번호 재설정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     //swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/teamddd/duckmap/advice/AuthAdvice.java
+++ b/src/main/java/com/teamddd/duckmap/advice/AuthAdvice.java
@@ -12,6 +12,7 @@ import com.teamddd.duckmap.dto.ErrorResult;
 import com.teamddd.duckmap.exception.InvalidMemberException;
 import com.teamddd.duckmap.exception.InvalidPasswordException;
 import com.teamddd.duckmap.exception.InvalidTokenException;
+import com.teamddd.duckmap.exception.InvalidUuidException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -64,4 +65,12 @@ public class AuthAdvice {
 			.build();
 	}
 
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler
+	public ErrorResult invalidUuidException(InvalidUuidException ex) {
+		return ErrorResult.builder()
+			.code(ExceptionCodeMessage.INVALID_UUID_EXCEPTION.code())
+			.message(ex.getMessage())
+			.build();
+	}
 }

--- a/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
+++ b/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
@@ -4,11 +4,15 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ExceptionCodeMessage {
+	/* Auth */
 	INVALID_TOKEN_EXCEPTION("A001", "유효하지 않은 토큰입니다"),
 	INVALID_MEMBER_EXCEPTION("A002", "유효하지 않은 이메일 혹은 비밀번호입니다"),
 	AUTHENTICATION_EXCEPTION("A003", "잘못된 인증입니다"),
 	ACCESS_DENIED_EXCEPTION("A004", "권한이 없는 사용자입니다"),
 	INVALID_PASSWORD_EXCEPTION("A005", "비밀번호가 맞지 않습니다"),
+	INVALID_UUID_EXCEPTION("A006", "유효하지 않은 UUID 입니다"),
+
+	/* Member */
 	DUPLICATE_EMAIL_EXCEPTION("M001", "이미 사용중인 이메일입니다"),
 	DUPLICATE_USERNAME_EXCEPTION("M002", "이미 사용중인 닉네임입니다"),
 

--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -15,7 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.teamddd.duckmap.config.security.TokenDto;
 import com.teamddd.duckmap.dto.user.auth.LoginReq;
+import com.teamddd.duckmap.dto.user.auth.VerificationReq;
 import com.teamddd.duckmap.service.AuthService;
+import com.teamddd.duckmap.service.MemberService;
+import com.teamddd.duckmap.service.SendMailService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/auth")
 public class AuthController {
 	private final AuthService authService;
+	private final MemberService memberService;
+	private final SendMailService mailService;
 	private static final long COOKIE_EXPIRATION = 604800;
 
 	@Operation(summary = "로그인")
@@ -105,6 +110,14 @@ public class AuthController {
 			.status(HttpStatus.OK)
 			.header(HttpHeaders.SET_COOKIE, responseCookie.toString())
 			.build();
+	}
+
+	//인증번호 생성 및 이메일 전송
+	@Operation(summary = "인증번호 생성 및 이메일 전송")
+	@PostMapping("/send-verification")
+	public String sendVerification(@Validated @RequestBody VerificationReq verificationReq) {
+		memberService.checkMemberByEmail(verificationReq.getEmail());
+		return mailService.sendVerification(verificationReq.getEmail());
 	}
 
 }

--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.teamddd.duckmap.config.security.TokenDto;
 import com.teamddd.duckmap.dto.user.auth.LoginReq;
-import com.teamddd.duckmap.dto.user.auth.VerificationReq;
+import com.teamddd.duckmap.dto.user.auth.SendResetPasswordEmailReq;
 import com.teamddd.duckmap.service.AuthService;
 import com.teamddd.duckmap.service.MemberService;
 import com.teamddd.duckmap.service.SendMailService;
@@ -112,12 +112,12 @@ public class AuthController {
 			.build();
 	}
 
-	//인증번호 생성 및 이메일 전송
-	@Operation(summary = "인증번호 생성 및 이메일 전송")
-	@PostMapping("/send-verification")
-	public String sendVerification(@Validated @RequestBody VerificationReq verificationReq) {
-		memberService.checkMemberByEmail(verificationReq.getEmail());
-		return mailService.sendVerification(verificationReq.getEmail());
+	//UUID 생성 및 이메일 전송
+	@Operation(summary = "UUID 생성 및 이메일 전송")
+	@PostMapping("/send-reset-password")
+	public String sendResetPassword(@Validated @RequestBody SendResetPasswordEmailReq resetPasswordEmailReq) {
+		memberService.checkMemberByEmail(resetPasswordEmailReq.getEmail());
+		return mailService.sendResetPasswordEmail(resetPasswordEmailReq.getEmail());
 	}
 
 }

--- a/src/main/java/com/teamddd/duckmap/controller/MemberController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/MemberController.java
@@ -15,6 +15,7 @@ import com.teamddd.duckmap.dto.user.CreateMemberReq;
 import com.teamddd.duckmap.dto.user.CreateMemberRes;
 import com.teamddd.duckmap.dto.user.DeleteMemberReq;
 import com.teamddd.duckmap.dto.user.MemberRes;
+import com.teamddd.duckmap.dto.user.ResetPasswordReq;
 import com.teamddd.duckmap.dto.user.UpdateMemberReq;
 import com.teamddd.duckmap.dto.user.UpdatePasswordReq;
 import com.teamddd.duckmap.service.AuthService;
@@ -66,6 +67,12 @@ public class MemberController {
 		Long id = memberService.validatePassword(deleteMemberReq.getPassword());
 		authService.logout(requestAccessToken);
 		memberService.deleteMember(id);
+	}
+
+	@Operation(summary = "비밀번호 재설정", description = "비밀번호를 새로 재설정")
+	@PatchMapping("/reset-password/{id}")
+	public void resetPassword(@Validated @RequestBody ResetPasswordReq resetPasswordReq) {
+		memberService.resetPassword(resetPasswordReq.getUuid(), resetPasswordReq.getNewPassword());
 	}
 
 }

--- a/src/main/java/com/teamddd/duckmap/dto/user/ResetPasswordReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/ResetPasswordReq.java
@@ -1,0 +1,16 @@
+package com.teamddd.duckmap.dto.user;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import lombok.Getter;
+
+@Getter
+public class ResetPasswordReq {
+	@NotBlank
+	private String uuid;
+	@NotBlank
+	@Pattern(regexp = "(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*]).{8,16}",
+		message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+	private String newPassword;
+}

--- a/src/main/java/com/teamddd/duckmap/dto/user/auth/SendResetPasswordEmailReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/auth/SendResetPasswordEmailReq.java
@@ -6,7 +6,7 @@ import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
-public class VerificationReq {
+public class SendResetPasswordEmailReq {
 	@NotBlank
 	@Email
 	private String email;

--- a/src/main/java/com/teamddd/duckmap/dto/user/auth/VerificationReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/user/auth/VerificationReq.java
@@ -1,0 +1,13 @@
+package com.teamddd.duckmap.dto.user.auth;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import lombok.Getter;
+
+@Getter
+public class VerificationReq {
+	@NotBlank
+	@Email
+	private String email;
+}

--- a/src/main/java/com/teamddd/duckmap/exception/InvalidUuidException.java
+++ b/src/main/java/com/teamddd/duckmap/exception/InvalidUuidException.java
@@ -1,0 +1,26 @@
+package com.teamddd.duckmap.exception;
+
+import com.teamddd.duckmap.common.ExceptionCodeMessage;
+
+public class InvalidUuidException extends RuntimeException {
+	public InvalidUuidException() {
+		super(ExceptionCodeMessage.INVALID_UUID_EXCEPTION.message());
+	}
+
+	public InvalidUuidException(String message) {
+		super(message);
+	}
+
+	public InvalidUuidException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidUuidException(Throwable cause) {
+		super(cause);
+	}
+
+	public InvalidUuidException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/service/MemberService.java
+++ b/src/main/java/com/teamddd/duckmap/service/MemberService.java
@@ -50,6 +50,10 @@ public class MemberService {
 		});
 	}
 
+	public void checkMemberByEmail(String email) {
+		memberRepository.findByEmail(email).orElseThrow(InvalidMemberException::new);
+	}
+
 	public MemberRes getMyInfoBySecurity() {
 		return memberRepository.findByEmail(MemberUtils.getAuthMember().getUsername())
 			.map(MemberRes::of)

--- a/src/main/java/com/teamddd/duckmap/service/MemberService.java
+++ b/src/main/java/com/teamddd/duckmap/service/MemberService.java
@@ -12,6 +12,7 @@ import com.teamddd.duckmap.exception.DuplicateEmailException;
 import com.teamddd.duckmap.exception.DuplicateUsernameException;
 import com.teamddd.duckmap.exception.InvalidMemberException;
 import com.teamddd.duckmap.exception.InvalidPasswordException;
+import com.teamddd.duckmap.exception.InvalidUuidException;
 import com.teamddd.duckmap.repository.MemberRepository;
 import com.teamddd.duckmap.util.MemberUtils;
 
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final RedisService redisService;
 
 	@Transactional
 	public Long join(CreateMemberReq createMemberReq) {
@@ -91,4 +93,24 @@ public class MemberService {
 		}
 		return member.getId();
 	}
+
+	@Transactional
+	public void resetPassword(String uuid, String newPassword) {
+		//redis에 uuid가 있는지 확인, 없으면 error
+		String email = redisService.getValues(uuid);
+		if (email == null) {
+			throw new InvalidUuidException();
+		}
+
+		//redis에서 uuid로 email을 찾아온다.
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(InvalidMemberException::new);
+
+		//비밀번호 재설정
+		member.updatePassword(passwordEncoder.encode((newPassword)));
+
+		//비밀번호 업데이트 후 redis에서 uuid를 지운다.
+		redisService.deleteValues(uuid);
+	}
+
 }

--- a/src/main/java/com/teamddd/duckmap/service/SendMailService.java
+++ b/src/main/java/com/teamddd/duckmap/service/SendMailService.java
@@ -1,8 +1,10 @@
 package com.teamddd.duckmap.service;
 
-import java.util.Random;
+import java.io.UnsupportedEncodingException;
+import java.util.UUID;
 
 import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,35 +20,39 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class SendMailService {
-
+	private final RedisService redisService;
 	@Value("${spring.mail.username}")
 	private String fromEmail;
+	@Value("${resetpassword.url}")
+	private String resetPwUrl;
 	@Autowired
 	JavaMailSender mailSender;
 
-	public int makeRandomNumber() {
-		Random random = new Random();
-		return random.nextInt(999999); // 랜덤 6자리 난수설정
+	public String makeUuid() {
+		return UUID.randomUUID().toString();
 	}
 
-	public String sendVerification(String email) {
-		int verifyCode = makeRandomNumber();
-		String setFrom = fromEmail;
-		String title = "비밀번호 찾기 인증번호 입니다."; // 이메일 제목
+	@Transactional
+	public String sendResetPasswordEmail(String email) {
+		String uuid = makeUuid();
+		String title = "요청하신 비밀번호 재설정 입니다."; // 이메일 제목
 		String content = "대동덕지도" //html 형식으로 작성
-			+ "<br><br>" + "인증 번호는 " + verifyCode + "입니다." + "<br>"
-			+ "해당 인증번호를 인증번호 확인란에 기입하여 주세요."; //이메일 내용 삽입
-		mailSend(setFrom, email, title, content);
-		return Integer.toString(verifyCode);
+			+ "<br><br>" + "아래 링크를 클릭하면 비밀번호 재설정 페이지로 이동합니다." + "<br>"
+			+ "<a href=\"" + resetPwUrl + "/" + uuid + "\">"
+			+ resetPwUrl + "/" + uuid + "</a>" + "<br><br>"
+			+ "해당 링크는 24시간 동안만 유효합니다." + "<br>"; //이메일 내용 삽입
+		mailSend(email, title, content);
+		saveUuidAndEmail(uuid, email);
+		return uuid;
 	}
 
 	//이메일 전송 메소드
-	public void mailSend(String setFrom, String toMail, String title, String content) {
+	public void mailSend(String toMail, String title, String content) {
 		MimeMessage message = mailSender.createMimeMessage();
 		// true 매개값을 전달하면 multipart 형식의 메세지 전달이 가능.문자 인코딩 설정도 가능하다.
 		try {
 			MimeMessageHelper helper = new MimeMessageHelper(message, true, "utf-8");
-			helper.setFrom(setFrom);
+			helper.setFrom(new InternetAddress(fromEmail, "대동덕지도"));
 			helper.setTo(toMail);
 			helper.setSubject(title);
 			// true 전달 > html 형식으로 전송 , 작성하지 않으면 단순 텍스트로 전달.
@@ -54,7 +60,18 @@ public class SendMailService {
 			mailSender.send(message);
 		} catch (MessagingException e) {
 			e.printStackTrace();
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
 		}
 
+	}
+
+	// UUID와 Email을 Redis에 저장
+	@Transactional
+	public void saveUuidAndEmail(String uuid, String email) {
+		long uuidValidTime = 60 * 60 * 24 * 1000L; // 24시간
+		redisService.setValuesWithTimeout(uuid, // key
+			email, // value
+			uuidValidTime); // timeout(milliseconds)
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/service/SendMailService.java
+++ b/src/main/java/com/teamddd/duckmap/service/SendMailService.java
@@ -1,0 +1,60 @@
+package com.teamddd.duckmap.service;
+
+import java.util.Random;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SendMailService {
+
+	@Value("${spring.mail.username}")
+	private String fromEmail;
+	@Autowired
+	JavaMailSender mailSender;
+
+	public int makeRandomNumber() {
+		Random random = new Random();
+		return random.nextInt(999999); // 랜덤 6자리 난수설정
+	}
+
+	public String sendVerification(String email) {
+		int verifyCode = makeRandomNumber();
+		String setFrom = fromEmail;
+		String title = "비밀번호 찾기 인증번호 입니다."; // 이메일 제목
+		String content = "대동덕지도" //html 형식으로 작성
+			+ "<br><br>" + "인증 번호는 " + verifyCode + "입니다." + "<br>"
+			+ "해당 인증번호를 인증번호 확인란에 기입하여 주세요."; //이메일 내용 삽입
+		mailSend(setFrom, email, title, content);
+		return Integer.toString(verifyCode);
+	}
+
+	//이메일 전송 메소드
+	public void mailSend(String setFrom, String toMail, String title, String content) {
+		MimeMessage message = mailSender.createMimeMessage();
+		// true 매개값을 전달하면 multipart 형식의 메세지 전달이 가능.문자 인코딩 설정도 가능하다.
+		try {
+			MimeMessageHelper helper = new MimeMessageHelper(message, true, "utf-8");
+			helper.setFrom(setFrom);
+			helper.setTo(toMail);
+			helper.setSubject(title);
+			// true 전달 > html 형식으로 전송 , 작성하지 않으면 단순 텍스트로 전달.
+			helper.setText(content, true);
+			mailSender.send(message);
+		} catch (MessagingException e) {
+			e.printStackTrace();
+		}
+
+	}
+}


### PR DESCRIPTION
## Description

> #249 비밀번호 재설정 구현

## Changes

- 사용자가 입력한 이메일로 비밀번호 재설정 링크를 포함한 이메일을 보냄(/auth/send-reset-password)
-비밀번호 찾기를 진행하는 회원의 비밀번호 재설정 (/members/reset-password)

## ETC
