### PR TITLE
event category 저장 기능 구현 및 api에 적용

### DIFF
--- a/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
+++ b/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
@@ -20,7 +20,10 @@ public enum ExceptionCodeMessage {
 	NON_EXISTENT_ARTIST_TYPE_EXCEPTION("AT001", "잘못된 아티스트 구분 정보입니다"),
 
 	/* Artist */
-	NON_EXISTENT_ARTIST_EXCEPTION("A001", "잘못된 아티스트 정보입니다");
+	NON_EXISTENT_ARTIST_EXCEPTION("A001", "잘못된 아티스트 정보입니다"),
+
+	/* EventCategory */
+	NON_EXISTENT_EVENT_CATEGORY_EXCEPTION("EC001", "잘못된 이벤트 카테고리 정보입니다");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/teamddd/duckmap/controller/EventCategoryController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventCategoryController.java
@@ -46,20 +46,7 @@ public class EventCategoryController {
 	@Operation(summary = "이벤트 카테고리 목록 조회")
 	@GetMapping
 	public List<EventCategoryRes> getEventCategories() {
-		return List.of(
-			EventCategoryRes.builder()
-				.id(1L)
-				.category("생일카페")
-				.build(),
-			EventCategoryRes.builder()
-				.id(2L)
-				.category("전시회")
-				.build(),
-			EventCategoryRes.builder()
-				.id(3L)
-				.category("럭키드로우")
-				.build()
-		);
+		return eventCategoryService.getEventCategoryResList();
 	}
 
 	@Operation(summary = "이벤트 카테고리 수정")

--- a/src/main/java/com/teamddd/duckmap/controller/EventCategoryController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventCategoryController.java
@@ -2,9 +2,6 @@ package com.teamddd.duckmap.controller;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -48,8 +45,8 @@ public class EventCategoryController {
 
 	@Operation(summary = "이벤트 카테고리 목록 조회")
 	@GetMapping
-	public Page<EventCategoryRes> getEventCategories(Pageable pageable) {
-		return new PageImpl<>(List.of(
+	public List<EventCategoryRes> getEventCategories() {
+		return List.of(
 			EventCategoryRes.builder()
 				.id(1L)
 				.category("생일카페")
@@ -62,7 +59,7 @@ public class EventCategoryController {
 				.id(3L)
 				.category("럭키드로우")
 				.build()
-		));
+		);
 	}
 
 	@Operation(summary = "이벤트 카테고리 수정")

--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -29,6 +29,9 @@ import com.teamddd.duckmap.dto.event.event.EventsRes;
 import com.teamddd.duckmap.dto.event.event.HashtagRes;
 import com.teamddd.duckmap.dto.event.event.UpdateEventReq;
 import com.teamddd.duckmap.dto.review.ReviewRes;
+import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.service.EventService;
+import com.teamddd.duckmap.util.MemberUtils;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -40,11 +43,17 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/events")
 public class EventController {
 
+	private final EventService eventService;
+
 	@Operation(summary = "이벤트 등록", description = "address 형식 변경 가능성 있음")
 	@PostMapping
 	public CreateEventRes createEvent(@Validated @RequestBody CreateEventReq createEventReq) {
+		Member member = MemberUtils.getAuthMember().getUser();
+
+		Long eventId = eventService.createEvent(createEventReq, member);
+
 		return CreateEventRes.builder()
-			.id(1L)
+			.id(eventId)
 			.build();
 	}
 

--- a/src/main/java/com/teamddd/duckmap/dto/event/category/EventCategoryRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/category/EventCategoryRes.java
@@ -1,5 +1,7 @@
 package com.teamddd.duckmap.dto.event.category;
 
+import com.teamddd.duckmap.entity.EventCategory;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,4 +10,11 @@ import lombok.Getter;
 public class EventCategoryRes {
 	private Long id;
 	private String category;
+
+	public static EventCategoryRes of(EventCategory eventCategory) {
+		return EventCategoryRes.builder()
+			.id(eventCategory.getId())
+			.category(eventCategory.getCategory())
+			.build();
+	}
 }

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/CreateEventReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/CreateEventReq.java
@@ -2,6 +2,7 @@ package com.teamddd.duckmap.dto.event.event;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -24,10 +25,10 @@ public class CreateEventReq {
 	private String twitterUrl;
 	@NotNull
 	@Size(min = 1)
-	private List<Long> artistIds;
+	private Set<Long> artistIds;
 	@NotNull
 	@Size(min = 1)
-	private List<Long> categoryIds;
+	private Set<Long> categoryIds;
 	@NotNull
 	@Size(min = 1)
 	private List<String> imageFilenames;

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/CreateEventReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/CreateEventReq.java
@@ -2,7 +2,6 @@ package com.teamddd.duckmap.dto.event.event;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Set;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -25,10 +24,10 @@ public class CreateEventReq {
 	private String twitterUrl;
 	@NotNull
 	@Size(min = 1)
-	private Set<Long> artistIds;
+	private List<Long> artistIds;
 	@NotNull
 	@Size(min = 1)
-	private Set<Long> categoryIds;
+	private List<Long> categoryIds;
 	@NotNull
 	@Size(min = 1)
 	private List<String> imageFilenames;

--- a/src/main/java/com/teamddd/duckmap/exception/NonExistentEventCategoryException.java
+++ b/src/main/java/com/teamddd/duckmap/exception/NonExistentEventCategoryException.java
@@ -1,0 +1,26 @@
+package com.teamddd.duckmap.exception;
+
+import com.teamddd.duckmap.common.ExceptionCodeMessage;
+
+public class NonExistentEventCategoryException extends RuntimeException {
+	public NonExistentEventCategoryException() {
+		super(ExceptionCodeMessage.NON_EXISTENT_EVENT_CATEGORY_EXCEPTION.message());
+	}
+
+	public NonExistentEventCategoryException(String message) {
+		super(message);
+	}
+
+	public NonExistentEventCategoryException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public NonExistentEventCategoryException(Throwable cause) {
+		super(cause);
+	}
+
+	public NonExistentEventCategoryException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/repository/ArtistRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/ArtistRepository.java
@@ -9,4 +9,6 @@ import com.teamddd.duckmap.entity.Artist;
 public interface ArtistRepository extends JpaRepository<Artist, Long>, ArtistRepositoryCustom {
 
 	List<Artist> findByGroup(Artist group);
+
+	List<Artist> findByIdIn(List<Long> id);
 }

--- a/src/main/java/com/teamddd/duckmap/repository/EventCategoryRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/EventCategoryRepository.java
@@ -1,8 +1,12 @@
 package com.teamddd.duckmap.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.teamddd.duckmap.entity.EventCategory;
 
 public interface EventCategoryRepository extends JpaRepository<EventCategory, Long> {
+
+	List<EventCategory> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/teamddd/duckmap/service/ArtistService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ArtistService.java
@@ -1,6 +1,8 @@
 package com.teamddd.duckmap.service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -52,6 +54,16 @@ public class ArtistService {
 	public Artist getArtist(Long artistId) throws NonExistentArtistException {
 		return artistRepository.findById(artistId)
 			.orElseThrow(NonExistentArtistException::new);
+	}
+
+	public List<Artist> getArtistsByIds(List<Long> ids) {
+		List<Artist> artists = artistRepository.findByIdIn(ids);
+
+		Set<Long> duplicatedIds = new HashSet<>(ids);
+		if (duplicatedIds.size() == artists.size()) {
+			return artists;
+		}
+		throw new NonExistentArtistException();
 	}
 
 	public Page<ArtistRes> getArtistResPageByTypeAndName(ArtistSearchParam artistSearchParam, Pageable pageable) {

--- a/src/main/java/com/teamddd/duckmap/service/EventCategoryService.java
+++ b/src/main/java/com/teamddd/duckmap/service/EventCategoryService.java
@@ -1,6 +1,8 @@
 package com.teamddd.duckmap.service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -9,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.teamddd.duckmap.dto.event.category.CreateEventCategoryReq;
 import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
 import com.teamddd.duckmap.entity.EventCategory;
+import com.teamddd.duckmap.exception.NonExistentEventCategoryException;
 import com.teamddd.duckmap.repository.EventCategoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -30,6 +33,16 @@ public class EventCategoryService {
 		eventCategoryRepository.save(eventCategory);
 
 		return eventCategory.getId();
+	}
+
+	public List<EventCategory> getEventCategoriesByIds(List<Long> ids) {
+		List<EventCategory> categories = eventCategoryRepository.findByIdIn(ids);
+
+		Set<Long> duplicatedIds = new HashSet<>(ids);
+		if (duplicatedIds.size() == categories.size()) {
+			return categories;
+		}
+		throw new NonExistentEventCategoryException();
 	}
 
 	public List<EventCategoryRes> getEventCategoryResList() {

--- a/src/main/java/com/teamddd/duckmap/service/EventCategoryService.java
+++ b/src/main/java/com/teamddd/duckmap/service/EventCategoryService.java
@@ -1,9 +1,13 @@
 package com.teamddd.duckmap.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.event.category.CreateEventCategoryReq;
+import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
 import com.teamddd.duckmap.entity.EventCategory;
 import com.teamddd.duckmap.repository.EventCategoryRepository;
 
@@ -26,5 +30,12 @@ public class EventCategoryService {
 		eventCategoryRepository.save(eventCategory);
 
 		return eventCategory.getId();
+	}
+
+	public List<EventCategoryRes> getEventCategoryResList() {
+		List<EventCategory> categories = eventCategoryRepository.findAll();
+		return categories.stream()
+			.map(EventCategoryRes::of)
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/service/EventService.java
+++ b/src/main/java/com/teamddd/duckmap/service/EventService.java
@@ -1,0 +1,74 @@
+package com.teamddd.duckmap.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.dto.event.event.CreateEventReq;
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventArtist;
+import com.teamddd.duckmap.entity.EventCategory;
+import com.teamddd.duckmap.entity.EventImage;
+import com.teamddd.duckmap.entity.EventInfoCategory;
+import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.repository.EventRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EventService {
+
+	private final EventRepository eventRepository;
+	private final ArtistService artistService;
+	private final EventCategoryService eventCategoryService;
+
+	@Transactional
+	public Long createEvent(CreateEventReq createEventReq, Member member) {
+		List<Artist> artists = artistService.getArtistsByIds(createEventReq.getArtistIds());
+		List<EventCategory> categories = eventCategoryService.getEventCategoriesByIds(
+			createEventReq.getCategoryIds());
+
+		Event event = Event.builder()
+			.member(member)
+			.storeName(createEventReq.getStoreName())
+			.fromDate(createEventReq.getFromDate())
+			.toDate(createEventReq.getToDate())
+			.address(createEventReq.getAddress())
+			.businessHour(createEventReq.getBusinessHour())
+			.hashtag(createEventReq.getHashtag())
+			.twitterUrl(createEventReq.getTwitterUrl())
+			.eventArtists(
+				artists.stream()
+					.map(artist -> EventArtist.builder()
+						.artist(artist)
+						.build())
+					.collect(Collectors.toList())
+			)
+			.eventInfoCategories(
+				categories.stream()
+					.map(category -> EventInfoCategory.builder()
+						.eventCategory(category)
+						.build())
+					.collect(Collectors.toList())
+			)
+			.eventImages(
+				createEventReq.getImageFilenames().stream()
+					.map(filename -> EventImage.builder()
+						.image(filename)
+						.build())
+					.collect(Collectors.toList())
+			)
+			.build();
+
+		eventRepository.save(event);
+
+		return event.getId();
+	}
+}

--- a/src/test/java/com/teamddd/duckmap/controller/EventCategoryControllerTest.java
+++ b/src/test/java/com/teamddd/duckmap/controller/EventCategoryControllerTest.java
@@ -5,6 +5,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teamddd.duckmap.dto.event.category.CreateEventCategoryReq;
+import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
 import com.teamddd.duckmap.service.EventCategoryService;
 
 @SpringBootTest
@@ -31,6 +34,22 @@ class EventCategoryControllerTest {
 	private ObjectMapper objectMapper;
 	@MockBean
 	private EventCategoryService eventCategoryService;
+
+	@DisplayName("이벤트 카테고리 전체 목록을 조회한다")
+	@Test
+	void getEventCategories() throws Exception {
+		//given
+		List<EventCategoryRes> result = List.of();
+		when(eventCategoryService.getEventCategoryResList()).thenReturn(result);
+
+		//when //then
+		mockMvc.perform(
+				get("/events/categories")
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$").isArray());
+	}
 
 	@DisplayName("이벤트 카테고리를 생성한다")
 	@Nested

--- a/src/test/java/com/teamddd/duckmap/repository/ArtistRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/ArtistRepositoryTest.java
@@ -62,6 +62,30 @@ class ArtistRepositoryTest {
 				Tuple.tuple(artist3.getId(), artist3.getName(), group1.getId()));
 	}
 
+	@DisplayName("pk 목록으로 artist 목록 조회")
+	@Test
+	void findByIdIn() throws Exception {
+		//given
+		Artist artist1 = createArtist("artist1", null, null);
+		Artist artist2 = createArtist("artist2", null, null);
+		Artist artist3 = createArtist("artist3", null, null);
+		Artist artist4 = createArtist("artist4", null, null);
+		em.persist(artist1);
+		em.persist(artist2);
+		em.persist(artist3);
+		em.persist(artist4);
+
+		List<Long> inIds = List.of(artist2.getId(), artist4.getId());
+
+		//when
+		List<Artist> findArtists = artistRepository.findByIdIn(inIds);
+
+		//then
+		assertThat(findArtists).hasSize(2)
+			.extracting("name")
+			.containsExactlyInAnyOrder("artist2", "artist4");
+	}
+
 	private ArtistType createArtistType(String type) {
 		return ArtistType.builder().type(type).build();
 	}

--- a/src/test/java/com/teamddd/duckmap/repository/EventCategoryRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/EventCategoryRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.teamddd.duckmap.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.entity.EventCategory;
+
+@Transactional
+@SpringBootTest
+class EventCategoryRepositoryTest {
+	@Autowired
+	EventCategoryRepository eventCategoryRepository;
+	@Autowired
+	EntityManager em;
+
+	@DisplayName("pk 목록으로 EventCategory 목록 조회")
+	@Test
+	void findByIdIn() throws Exception {
+		//given
+		EventCategory category1 = createEventCategory("category1");
+		EventCategory category2 = createEventCategory("category2");
+		EventCategory category3 = createEventCategory("category3");
+		EventCategory category4 = createEventCategory("category4");
+		em.persist(category1);
+		em.persist(category2);
+		em.persist(category3);
+		em.persist(category4);
+
+		List<Long> inIds = List.of(category1.getId(), category4.getId());
+
+		//when
+		List<EventCategory> findCategories = eventCategoryRepository.findByIdIn(inIds);
+
+		//then
+		assertThat(findCategories).hasSize(2)
+			.extracting("category")
+			.containsExactlyInAnyOrder("category1", "category4");
+	}
+
+	EventCategory createEventCategory(String category) {
+		return EventCategory.builder()
+			.category(category)
+			.build();
+	}
+
+}

--- a/src/test/java/com/teamddd/duckmap/service/EventCategoryServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/EventCategoryServiceTest.java
@@ -2,6 +2,7 @@ package com.teamddd.duckmap.service;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +14,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.event.category.CreateEventCategoryReq;
+import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
 import com.teamddd.duckmap.entity.EventCategory;
 import com.teamddd.duckmap.repository.EventCategoryRepository;
 
@@ -42,6 +44,30 @@ class EventCategoryServiceTest {
 		assertThat(findCategory.get())
 			.extracting("category")
 			.isEqualTo("category1");
+	}
+
+	@DisplayName("이벤트 카테고리 전체 목록을 조회한다")
+	@Test
+	void getEventCategoryResList() throws Exception {
+		//given
+		EventCategory category1 = createEventCategory("category1");
+		EventCategory category2 = createEventCategory("category2");
+		EventCategory category3 = createEventCategory("category3");
+		eventCategoryRepository.saveAll(List.of(category1, category2, category3));
+
+		//when
+		List<EventCategoryRes> eventCategoryResList = eventCategoryService.getEventCategoryResList();
+
+		//then
+		assertThat(eventCategoryResList).hasSize(3)
+			.extracting("category")
+			.containsExactlyInAnyOrder("category1", "category2", "category3");
+	}
+
+	EventCategory createEventCategory(String category) {
+		return EventCategory.builder()
+			.category(category)
+			.build();
 	}
 
 }

--- a/src/test/java/com/teamddd/duckmap/service/EventServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/EventServiceTest.java
@@ -1,0 +1,73 @@
+package com.teamddd.duckmap.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.dto.event.event.CreateEventReq;
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventCategory;
+import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.repository.EventRepository;
+
+@Transactional
+@SpringBootTest
+class EventServiceTest {
+	@Autowired
+	EventService eventService;
+	@SpyBean
+	EventRepository eventRepository;
+	@MockBean
+	ArtistService artistService;
+	@MockBean
+	EventCategoryService eventCategoryService;
+
+	@DisplayName("이벤트를 생성한다")
+	@Test
+	void createEvent() throws Exception {
+		//given
+		CreateEventReq request = new CreateEventReq();
+		ReflectionTestUtils.setField(request, "storeName", "store name");
+		ReflectionTestUtils.setField(request, "fromDate", LocalDate.now());
+		ReflectionTestUtils.setField(request, "toDate", LocalDate.now());
+		ReflectionTestUtils.setField(request, "address", "address");
+		ReflectionTestUtils.setField(request, "artistIds", List.of(1L));
+		ReflectionTestUtils.setField(request, "categoryIds", List.of(1L));
+		ReflectionTestUtils.setField(request, "imageFilenames", List.of("filename"));
+
+		Member member = Member.builder()
+			.username("member1")
+			.build();
+
+		List<Artist> artists = List.of();
+		List<EventCategory> categories = List.of();
+		when(artistService.getArtistsByIds(any())).thenReturn(artists);
+		when(eventCategoryService.getEventCategoriesByIds(any())).thenReturn(categories);
+
+		//when
+		Long eventId = eventService.createEvent(request, member);
+
+		//then
+		assertThat(eventId).isNotNull();
+
+		Optional<Event> findEvent = eventRepository.findById(eventId);
+		assertThat(findEvent).isNotEmpty();
+		assertThat(findEvent.get())
+			.extracting("storeName", "member.username")
+			.containsOnly("store name", "member1");
+	}
+
+}


### PR DESCRIPTION
## Description

> event category 저장 기능 구현 및 api에 적용

## Changes

- EventService
  - createEvent()
    - 아티스트 pk 확인을 위해 ArtistService getArtistsByIds(), ArtistRepository findByIdIn() 구현
    - 이벤트 카테고리 pk 확인을 위해 EventCategoryService getEventCategoriesByIds(), EventCategoryRepository findByIdIn() 구현
- EventController
  - POST /events

## ETC
