### PR TITLE
Feat: #279 - event 상세 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
+++ b/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
@@ -27,7 +27,10 @@ public enum ExceptionCodeMessage {
 	NON_EXISTENT_ARTIST_EXCEPTION("A001", "잘못된 아티스트 정보입니다"),
 
 	/* EventCategory */
-	NON_EXISTENT_EVENT_CATEGORY_EXCEPTION("EC001", "잘못된 이벤트 카테고리 정보입니다");
+	NON_EXISTENT_EVENT_CATEGORY_EXCEPTION("EC001", "잘못된 이벤트 카테고리 정보입니다"),
+
+	/* Event */
+	NON_EXISTENT_EVENT_EXCEPTION("E001", "잘못된 이벤트 정보입니다");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -1,7 +1,6 @@
 package com.teamddd.duckmap.controller;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -29,7 +28,6 @@ import com.teamddd.duckmap.dto.event.event.EventSearchParam;
 import com.teamddd.duckmap.dto.event.event.EventsRes;
 import com.teamddd.duckmap.dto.event.event.HashtagRes;
 import com.teamddd.duckmap.dto.event.event.UpdateEventReq;
-import com.teamddd.duckmap.dto.review.ReviewRes;
 import com.teamddd.duckmap.entity.Member;
 import com.teamddd.duckmap.service.EventService;
 import com.teamddd.duckmap.util.MemberUtils;
@@ -100,29 +98,6 @@ public class EventController {
 			.like(true)
 			.likeCount(23)
 			.bookmark(false)
-			.reviews(List.of(
-				ReviewRes.builder()
-					.id(1L)
-					.userProfile(imageRes)
-					.username("user_nickname")
-					.createdAt(LocalDateTime.now().minusDays(2))
-					.score(5)
-					.content("review content")
-					.photos(List.of(
-						imageRes,
-						imageRes
-					))
-					.build(),
-				ReviewRes.builder()
-					.id(2L)
-					.userProfile(imageRes)
-					.username("user2_nickname")
-					.createdAt(LocalDateTime.now().minusDays(3))
-					.score(4)
-					.content("review content")
-					.photos(List.of(imageRes))
-					.build()
-			))
 			.build();
 	}
 

--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -1,5 +1,6 @@
 package com.teamddd.duckmap.controller;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -68,8 +69,8 @@ public class EventController {
 			.id(id)
 			.storeName("상호명")
 			.inProgress(true)
-			.fromDate(LocalDateTime.now().minusDays(2L))
-			.toDate(LocalDateTime.now().plusDays(1L))
+			.fromDate(LocalDate.now().minusDays(2L))
+			.toDate(LocalDate.now().plusDays(1L))
 			.address("주소")
 			.businessHour("10:00 - 18:00")
 			.hashtag("#뫄뫄 #생일축하해")

--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -59,46 +59,13 @@ public class EventController {
 	@Operation(summary = "이벤트 pk로 조회")
 	@GetMapping("/{id}")
 	public EventRes getEvent(@PathVariable Long id) {
-		ImageRes imageRes = ImageRes.builder()
-			.filename("filename.png")
-			.build();
+		Long memberId = MemberUtils.getMember()
+			.map(Member::getId)
+			.orElse(null);
 
-		return EventRes.builder()
-			.id(id)
-			.storeName("상호명")
-			.inProgress(true)
-			.fromDate(LocalDate.now().minusDays(2L))
-			.toDate(LocalDate.now().plusDays(1L))
-			.address("주소")
-			.businessHour("10:00 - 18:00")
-			.hashtag("#뫄뫄 #생일축하해")
-			.twitterUrl("https://twitter.com/home?lang=ko")
-			.artists(List.of(
-				ArtistRes.builder()
-					.id(2L)
-					.groupId(1L)
-					.name("태연")
-					.image(imageRes)
-					.artistType(
-						ArtistTypeRes.builder()
-							.id(1L)
-							.type("아이돌")
-							.build()
-					)
-					.build()
-			))
-			.categories(List.of(
-				EventCategoryRes.builder()
-					.id(1L)
-					.category("생일카페")
-					.build()
-			))
-			.images(List.of(imageRes))
-			.score(4.5)
-			.like(true)
-			.likeCount(23)
-			.bookmark(false)
-			.build();
+		LocalDate today = LocalDate.now();
+
+		return eventService.getEventRes(id, memberId, today);
 	}
 
 	@Operation(summary = "이벤트 수정")

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventRes.java
@@ -6,7 +6,6 @@ import java.util.List;
 import com.teamddd.duckmap.dto.ImageRes;
 import com.teamddd.duckmap.dto.artist.ArtistRes;
 import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
-import com.teamddd.duckmap.dto.review.ReviewRes;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +30,4 @@ public class EventRes {
 	private boolean like;
 	private int likeCount;
 	private boolean bookmark;
-
-	private List<ReviewRes> reviews;
 }

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventRes.java
@@ -1,6 +1,6 @@
 package com.teamddd.duckmap.dto.event.event;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.teamddd.duckmap.dto.ImageRes;
@@ -17,8 +17,8 @@ public class EventRes {
 	private Long id;
 	private String storeName;
 	private boolean inProgress;
-	private LocalDateTime fromDate;
-	private LocalDateTime toDate;
+	private LocalDate fromDate;
+	private LocalDate toDate;
 	private String address;
 	private String businessHour;
 	private String hashtag;

--- a/src/main/java/com/teamddd/duckmap/entity/Event.java
+++ b/src/main/java/com/teamddd/duckmap/entity/Event.java
@@ -51,4 +51,9 @@ public class Event extends BaseTimeEntity {
 
 	@OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<EventImage> eventImages = new ArrayList<>();
+
+	public boolean isInProgress(LocalDate date) {
+		return (date.isEqual(fromDate) || date.isAfter(fromDate))
+			&& (date.isEqual(toDate) || date.isBefore(toDate));
+	}
 }

--- a/src/main/java/com/teamddd/duckmap/exception/NonExistentEventException.java
+++ b/src/main/java/com/teamddd/duckmap/exception/NonExistentEventException.java
@@ -1,0 +1,26 @@
+package com.teamddd.duckmap.exception;
+
+import com.teamddd.duckmap.common.ExceptionCodeMessage;
+
+public class NonExistentEventException extends RuntimeException {
+	public NonExistentEventException() {
+		super(ExceptionCodeMessage.NON_EXISTENT_EVENT_EXCEPTION.message());
+	}
+
+	public NonExistentEventException(String message) {
+		super(message);
+	}
+
+	public NonExistentEventException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public NonExistentEventException(Throwable cause) {
+		super(cause);
+	}
+
+	public NonExistentEventException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/repository/ReviewRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/ReviewRepository.java
@@ -1,8 +1,12 @@
 package com.teamddd.duckmap.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.teamddd.duckmap.entity.Event;
 import com.teamddd.duckmap.entity.Member;
@@ -12,4 +16,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 	Page<Review> findByMember(Member member, Pageable pageable);
 
 	Page<Review> findByEvent(Event event, Pageable pageable);
+
+	@Query("select ROUND(avg(r.score), 1) from Review r where r.event.id = :eventId")
+	Optional<Double> avgScoreByEvent(@Param("eventId") Long eventId);
 }

--- a/src/test/java/com/teamddd/duckmap/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/ReviewRepositoryTest.java
@@ -3,6 +3,7 @@ package com.teamddd.duckmap.repository;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import javax.persistence.EntityManager;
 
@@ -24,7 +25,7 @@ import com.teamddd.duckmap.entity.Review;
 
 @Transactional
 @SpringBootTest
-public class ReviewRepositoryTest {
+class ReviewRepositoryTest {
 	@Autowired
 	ReviewRepository reviewRepository;
 	@Autowired
@@ -141,6 +142,37 @@ public class ReviewRepositoryTest {
 
 		assertThat(reviews2.getTotalElements()).isEqualTo(2);
 		assertThat(reviews2.getTotalPages()).isEqualTo(1);
+	}
+
+	@DisplayName("Event fk로 조회한 Review 목록의 score 평균 계산")
+	@Test
+	void avgScoreByEvent() throws Exception {
+		//given
+		Event event = createEvent("event");
+		em.persist(event);
+
+		// score sum = 25, avg = 4.1666...
+		Review review1 = createReview(null, event, "", 3);
+		Review review2 = createReview(null, event, "", 4);
+		Review review3 = createReview(null, event, "", 3);
+		Review review4 = createReview(null, event, "", 5);
+		Review review5 = createReview(null, event, "", 5);
+		Review review6 = createReview(null, event, "", 5);
+		em.persist(review1);
+		em.persist(review2);
+		em.persist(review3);
+		em.persist(review4);
+		em.persist(review5);
+		em.persist(review6);
+
+		Long eventId = event.getId();
+
+		//when
+		Optional<Double> avgScore = reviewRepository.avgScoreByEvent(eventId);
+
+		//then
+		assertThat(avgScore).isNotEmpty();
+		assertThat(avgScore.get()).isEqualTo(4.2);
 	}
 
 	private Event createEvent(String storeName) {

--- a/src/test/java/com/teamddd/duckmap/service/EventServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/EventServiceTest.java
@@ -7,6 +7,9 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import javax.persistence.EntityManager;
+
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,15 +20,23 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.event.event.CreateEventReq;
+import com.teamddd.duckmap.dto.event.event.EventRes;
 import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.ArtistType;
 import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventArtist;
 import com.teamddd.duckmap.entity.EventCategory;
+import com.teamddd.duckmap.entity.EventInfoCategory;
 import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.repository.EventLikeRepository;
 import com.teamddd.duckmap.repository.EventRepository;
+import com.teamddd.duckmap.repository.ReviewRepository;
 
 @Transactional
 @SpringBootTest
 class EventServiceTest {
+	@Autowired
+	EntityManager em;
 	@Autowired
 	EventService eventService;
 	@SpyBean
@@ -34,6 +45,10 @@ class EventServiceTest {
 	ArtistService artistService;
 	@MockBean
 	EventCategoryService eventCategoryService;
+	@MockBean
+	ReviewRepository reviewRepository;
+	@MockBean
+	EventLikeRepository eventLikeRepository;
 
 	@DisplayName("이벤트를 생성한다")
 	@Test
@@ -48,9 +63,7 @@ class EventServiceTest {
 		ReflectionTestUtils.setField(request, "categoryIds", List.of(1L));
 		ReflectionTestUtils.setField(request, "imageFilenames", List.of("filename"));
 
-		Member member = Member.builder()
-			.username("member1")
-			.build();
+		Member member = Member.builder().username("member1").build();
 
 		List<Artist> artists = List.of();
 		List<EventCategory> categories = List.of();
@@ -65,9 +78,94 @@ class EventServiceTest {
 
 		Optional<Event> findEvent = eventRepository.findById(eventId);
 		assertThat(findEvent).isNotEmpty();
-		assertThat(findEvent.get())
-			.extracting("storeName", "member.username")
-			.containsOnly("store name", "member1");
+		assertThat(findEvent.get()).extracting("storeName", "member.username").containsOnly("store name", "member1");
 	}
 
+	@DisplayName("Event Id로 EventRes 조회")
+	@Test
+	void getEventRes() throws Exception {
+		//given
+		LocalDate now = LocalDate.now();
+
+		// save Artist
+		ArtistType artistType = createArtistType();
+		em.persist(artistType);
+		Artist artist1 = createArtist("artist1", artistType);
+		Artist artist2 = createArtist("artist2", artistType);
+		em.persist(artist1);
+		em.persist(artist2);
+
+		// save EventCategory
+		EventCategory eventCategory1 = createEventCategory("event_category1");
+		EventCategory eventCategory2 = createEventCategory("event_category2");
+		em.persist(eventCategory1);
+		em.persist(eventCategory2);
+
+		// save Event
+		Event event = createEvent(null, "event1", now, now.plusDays(2), "#hashtag");
+		em.persist(event);
+		Long eventId = event.getId();
+
+		// Artist, EventCategory -> event
+		EventArtist eventArtist1 = createEventArtist(event, artist1);
+		EventArtist eventArtist2 = createEventArtist(event, artist2);
+		em.persist(eventArtist1);
+		em.persist(eventArtist2);
+		EventInfoCategory eventInfoCategory1 = createEventInfoCategory(event, eventCategory1);
+		EventInfoCategory eventInfoCategory2 = createEventInfoCategory(event, eventCategory2);
+		em.persist(eventInfoCategory1);
+		em.persist(eventInfoCategory2);
+
+		em.flush();
+		em.clear();
+
+		// MockBean
+		Long likeCount = 12L;
+		Optional<Double> score = Optional.of(4.4);
+		when(eventLikeRepository.countByEventId(eventId)).thenReturn(likeCount);
+		when(reviewRepository.avgScoreByEvent(eventId)).thenReturn(score);
+
+		//when
+		EventRes eventRes = eventService.getEventRes(eventId, null, now);
+
+		//then
+		assertThat(eventRes).extracting("id", "storeName", "inProgress", "like", "bookmark", "score", "likeCount")
+			.containsOnly(eventId, "event1", true, false, false, 4.4, 12);
+
+		assertThat(eventRes.getArtists()).extracting("name", "artistType.type")
+			.containsExactlyInAnyOrder(Tuple.tuple("artist1", "artist_type"), Tuple.tuple("artist2", "artist_type"));
+		assertThat(eventRes.getCategories()).extracting("category")
+			.containsExactlyInAnyOrder("event_category1", "event_category2");
+	}
+
+	Event createEvent(Member member, String storeName, LocalDate fromDate, LocalDate toDate, String hashtag) {
+		return Event.builder()
+			.member(member)
+			.storeName(storeName)
+			.fromDate(fromDate)
+			.toDate(toDate)
+			.hashtag(hashtag)
+			.eventImages(List.of())
+			.build();
+	}
+
+	ArtistType createArtistType() {
+		return ArtistType.builder().type("artist_type").build();
+	}
+
+	Artist createArtist(String name, ArtistType type) {
+		return Artist.builder().name(name).artistType(type).build();
+	}
+
+	EventArtist createEventArtist(Event event, Artist artist) {
+		return EventArtist.builder().event(event).artist(artist).build();
+	}
+
+	EventCategory createEventCategory(String category) {
+		return EventCategory.builder().category(category).build();
+	}
+
+	EventInfoCategory createEventInfoCategory(Event event, EventCategory category) {
+		return EventInfoCategory.builder().event(event).eventCategory(category).build();
+	}
 }


### PR DESCRIPTION
## Description

> event 상세 정보 조회 기능 구현

## Changes

- EventRes fromDate, toDate LocalDate로 변경
- EventRes review 목록 제거
- ReviewRepository Event의 평점 계산 기능 구현
- Event 진행중 여부 확인 기능 구현
- EventService getEventRes()

## ETC
추후 리팩토링 예정
- EventArtist을 ArtistRes변환 과정에서 query 3번
  - from event_artist where event.id = ?
  - from artist where id in (?,?)
  - from artist_type where id = ?
- EventInfoCategory을 EventCategoryRes변환 과정에서 query 2번
  - from event_info_category where event.id = ?
  - from event_category where id in (?, ?)
- EventRes boolean like, bookmark -> pk 반환
