### PR TITLE
이벤트 좋아요, 좋아요 취소 기능 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/advice/ServiceAdvice.java
+++ b/src/main/java/com/teamddd/duckmap/advice/ServiceAdvice.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.teamddd.duckmap.common.ExceptionCodeMessage;
 import com.teamddd.duckmap.dto.ErrorResult;
+import com.teamddd.duckmap.exception.NonExistentEventLikeException;
 import com.teamddd.duckmap.exception.NonExistentFileException;
+import com.teamddd.duckmap.exception.NonExistentMemberException;
 import com.teamddd.duckmap.exception.ServiceException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +32,24 @@ public class ServiceAdvice {
 	public ErrorResult nonExistentFileException(NonExistentFileException ex) {
 		return ErrorResult.builder()
 			.code(ExceptionCodeMessage.NON_EXISTENT_FILE_EXCEPTION.code())
+			.message(ex.getMessage())
+			.build();
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler
+	public ErrorResult nonExistentMemberException(NonExistentMemberException ex) {
+		return ErrorResult.builder()
+			.code(ExceptionCodeMessage.NON_EXISTENT_MEMBER_EXCEPTION.code())
+			.message(ex.getMessage())
+			.build();
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler
+	public ErrorResult nonExistentEventLikeMemberException(NonExistentEventLikeException ex) {
+		return ErrorResult.builder()
+			.code(ExceptionCodeMessage.NON_EXISTENT_EVENT_LIKE_EXCEPTION.code())
 			.message(ex.getMessage())
 			.build();
 	}

--- a/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
+++ b/src/main/java/com/teamddd/duckmap/common/ExceptionCodeMessage.java
@@ -16,9 +16,13 @@ public enum ExceptionCodeMessage {
 	/* Member */
 	DUPLICATE_EMAIL_EXCEPTION("M001", "이미 사용중인 이메일입니다"),
 	DUPLICATE_USERNAME_EXCEPTION("M002", "이미 사용중인 닉네임입니다"),
+	NON_EXISTENT_MEMBER_EXCEPTION("M003", "잘못된 사용자 정보입니다"),
 
 	/* Event */
 	NON_EXISTENT_EVENT_EXCEPTION("E001", "잘못된 이벤트 정보입니다"),
+
+	/* Event Like */
+	NON_EXISTENT_EVENT_LIKE_EXCEPTION("EL001", "잘못된 이벤트 좋아요 정보입니다"),
 
 	/* Review */
 	NON_EXISTENT_REVIEW_EXCEPTION("R001", "잘못된 리뷰 정보입니다"),

--- a/src/main/java/com/teamddd/duckmap/controller/LikeController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/LikeController.java
@@ -1,7 +1,5 @@
 package com.teamddd.duckmap.controller;
 
-import javax.servlet.http.HttpSession;
-
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +7,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.teamddd.duckmap.dto.event.like.LikeRes;
+import com.teamddd.duckmap.entity.EventLike;
+import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.service.EventLikeService;
+import com.teamddd.duckmap.util.MemberUtils;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -19,18 +21,22 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @RequestMapping("/events")
 public class LikeController {
+	private final EventLikeService eventLikeService;
 
 	@Operation(summary = "이벤트 좋아요")
 	@PostMapping("/{id}/likes")
-	public LikeRes likeEvent(@PathVariable Long id, HttpSession session) {
+	public LikeRes likeEvent(@PathVariable Long id) {
+		Member member = MemberUtils.getAuthMember().getUser();
+		EventLike eventLike = eventLikeService.likeEvent(id, member);
 		return LikeRes.builder()
-			.id(1L)
+			.id(eventLike.getId())
 			.build();
 	}
 
 	@Operation(summary = "이벤트 좋아요 취소")
 	@DeleteMapping("/{id}/likes")
 	public void deleteLikeEvent(@PathVariable Long id) {
-
+		Member member = MemberUtils.getAuthMember().getUser();
+		eventLikeService.deleteLikeEvent(id, member.getId());
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/exception/NonExistentEventLikeException.java
+++ b/src/main/java/com/teamddd/duckmap/exception/NonExistentEventLikeException.java
@@ -1,0 +1,26 @@
+package com.teamddd.duckmap.exception;
+
+import com.teamddd.duckmap.common.ExceptionCodeMessage;
+
+public class NonExistentEventLikeException extends RuntimeException {
+	public NonExistentEventLikeException() {
+		super(ExceptionCodeMessage.NON_EXISTENT_EVENT_LIKE_EXCEPTION.message());
+	}
+
+	public NonExistentEventLikeException(String message) {
+		super(message);
+	}
+
+	public NonExistentEventLikeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public NonExistentEventLikeException(Throwable cause) {
+		super(cause);
+	}
+
+	public NonExistentEventLikeException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/exception/NonExistentMemberException.java
+++ b/src/main/java/com/teamddd/duckmap/exception/NonExistentMemberException.java
@@ -1,0 +1,26 @@
+package com.teamddd.duckmap.exception;
+
+import com.teamddd.duckmap.common.ExceptionCodeMessage;
+
+public class NonExistentMemberException extends RuntimeException {
+	public NonExistentMemberException() {
+		super(ExceptionCodeMessage.NON_EXISTENT_MEMBER_EXCEPTION.message());
+	}
+
+	public NonExistentMemberException(String message) {
+		super(message);
+	}
+
+	public NonExistentMemberException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public NonExistentMemberException(Throwable cause) {
+		super(cause);
+	}
+
+	public NonExistentMemberException(String message, Throwable cause, boolean enableSuppression,
+		boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/repository/EventLikeRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/EventLikeRepository.java
@@ -1,10 +1,17 @@
 package com.teamddd.duckmap.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.teamddd.duckmap.entity.EventLike;
+import com.teamddd.duckmap.entity.Member;
 
 public interface EventLikeRepository extends JpaRepository<EventLike, Long> {
 	Long countByEventId(Long eventId);
 
+	@Query("select el.member from EventLike el where el.id = :id")
+	Optional<Member> findMemberById(@Param("id") Long id);
 }

--- a/src/main/java/com/teamddd/duckmap/repository/EventLikeRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/EventLikeRepository.java
@@ -1,17 +1,9 @@
 package com.teamddd.duckmap.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.teamddd.duckmap.entity.EventLike;
-import com.teamddd.duckmap.entity.Member;
 
 public interface EventLikeRepository extends JpaRepository<EventLike, Long> {
 	Long countByEventId(Long eventId);
-
-	@Query("select el.member from EventLike el where el.id = :id")
-	Optional<Member> findMemberById(@Param("id") Long id);
 }

--- a/src/main/java/com/teamddd/duckmap/service/EventLikeService.java
+++ b/src/main/java/com/teamddd/duckmap/service/EventLikeService.java
@@ -1,0 +1,49 @@
+package com.teamddd.duckmap.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventLike;
+import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.exception.AuthenticationRequiredException;
+import com.teamddd.duckmap.exception.NonExistentEventLikeException;
+import com.teamddd.duckmap.repository.EventLikeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EventLikeService {
+	private final EventService eventService;
+	private final EventLikeRepository eventLikeRepository;
+
+	@Transactional
+	public EventLike likeEvent(Long eventId, Member member) {
+		Event event = eventService.getEvent(eventId);
+
+		EventLike eventLike = EventLike.builder()
+			.event(event)
+			.member(member)
+			.build();
+
+		eventLikeRepository.save(eventLike);
+
+		return eventLike;
+	}
+
+	@Transactional
+	public void deleteLikeEvent(Long id, Long loginMemberId) {
+		EventLike eventLike = getEventLike(id);
+		if (!loginMemberId.equals(eventLike.getMember().getId())) {
+			throw new AuthenticationRequiredException();
+		}
+		eventLikeRepository.deleteById(id);
+	}
+
+	public EventLike getEventLike(Long likeId) throws NonExistentEventLikeException {
+		return eventLikeRepository.findById(likeId)
+			.orElseThrow(NonExistentEventLikeException::new);
+	}
+}

--- a/src/test/java/com/teamddd/duckmap/repository/EventLikeRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/EventLikeRepositoryTest.java
@@ -2,6 +2,8 @@ package com.teamddd.duckmap.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Optional;
+
 import javax.persistence.EntityManager;
 
 import org.junit.jupiter.api.Test;
@@ -67,5 +69,26 @@ public class EventLikeRepositoryTest {
 
 	private EventLike createEventLike(Member member, Event event) {
 		return EventLike.builder().member(member).event(event).build();
+	}
+
+	@Test
+	void getMemberById() throws Exception {
+		//given
+		Member member1 = Member.builder().username("member1").build();
+		em.persist(member1);
+
+		Event event1 = createEvent(member1, "event1");
+		em.persist(event1);
+
+		EventLike eventLike1 = createEventLike(member1, event1);
+		em.persist(eventLike1);
+
+		//when
+		Optional<Member> member = eventLikeRepository.findMemberById(eventLike1.getId());
+		Member findMember = member.get();
+
+		//then
+		assertThat(findMember.getUsername()).isEqualTo("member1");
+
 	}
 }

--- a/src/test/java/com/teamddd/duckmap/repository/EventLikeRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/EventLikeRepositoryTest.java
@@ -2,8 +2,6 @@ package com.teamddd.duckmap.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.Optional;
-
 import javax.persistence.EntityManager;
 
 import org.junit.jupiter.api.Test;
@@ -71,24 +69,4 @@ public class EventLikeRepositoryTest {
 		return EventLike.builder().member(member).event(event).build();
 	}
 
-	@Test
-	void getMemberById() throws Exception {
-		//given
-		Member member1 = Member.builder().username("member1").build();
-		em.persist(member1);
-
-		Event event1 = createEvent(member1, "event1");
-		em.persist(event1);
-
-		EventLike eventLike1 = createEventLike(member1, event1);
-		em.persist(eventLike1);
-
-		//when
-		Optional<Member> member = eventLikeRepository.findMemberById(eventLike1.getId());
-		Member findMember = member.get();
-
-		//then
-		assertThat(findMember.getUsername()).isEqualTo("member1");
-
-	}
 }

--- a/src/test/java/com/teamddd/duckmap/service/EventLikeServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/EventLikeServiceTest.java
@@ -1,0 +1,128 @@
+package com.teamddd.duckmap.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventLike;
+import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.exception.AuthenticationRequiredException;
+import com.teamddd.duckmap.repository.EventLikeRepository;
+
+@Transactional
+@SpringBootTest
+public class EventLikeServiceTest {
+	@Autowired
+	EventLikeService eventLikeService;
+	@SpyBean
+	EventLikeRepository eventLikeRepository;
+	@MockBean
+	EventService eventService;
+	@Autowired
+	EntityManager em;
+
+	@DisplayName("이벤트 좋아요")
+	@Test
+	void likeEvent() throws Exception {
+		//given
+		Member member = Member.builder()
+			.username("member1")
+			.build();
+
+		Event event = Event.builder()
+			.storeName("store")
+			.member(member)
+			.build();
+
+		when(eventService.getEvent(any())).thenReturn(event);
+
+		//when
+		EventLike eventLike = eventLikeService.likeEvent(event.getId(), member);
+		Long likeId = eventLike.getId();
+
+		//then
+		assertThat(likeId).isNotNull();
+
+		Optional<EventLike> findLike = eventLikeRepository.findById(likeId);
+		assertThat(findLike).isNotEmpty();
+		assertThat(findLike.get())
+			.extracting("event.storeName", "member.username")
+			.containsOnly("store", "member1");
+	}
+
+	@DisplayName("이벤트 좋아요 취소")
+	@Nested
+	class DeleteLikeEvent {
+		@DisplayName("로그인 사용자와 좋아요한 사용자가 같을때")
+		@Test
+		void deleteLikeEvent1() throws Exception {
+			//given
+			Member member = Member.builder()
+				.username("member1")
+				.build();
+			em.persist(member);
+
+			Event event = Event.builder()
+				.storeName("store")
+				.member(member)
+				.build();
+			em.persist(event);
+
+			when(eventService.getEvent(any())).thenReturn(event);
+			EventLike eventLike = eventLikeService.likeEvent(event.getId(), member);
+
+			//when
+			Long likeId = eventLike.getId();
+			eventLikeService.deleteLikeEvent(likeId, member.getId());
+
+			//then
+			Optional<EventLike> findLike = eventLikeRepository.findById(likeId);
+			assertThat(findLike).isEmpty();
+		}
+
+		@DisplayName("로그인 사용자와 좋아요한 사용자가 다를때")
+		@Test
+		void deleteLikeEvent2() throws Exception {
+			//given
+			Member member = Member.builder()
+				.username("member1")
+				.build();
+			Member loginMember = Member.builder()
+				.username("member2")
+				.build();
+			em.persist(member);
+			em.persist(loginMember);
+
+			Event event = Event.builder()
+				.storeName("store")
+				.member(member)
+				.build();
+			em.persist(event);
+
+			when(eventService.getEvent(event.getId())).thenReturn(event);
+			EventLike eventLike = eventLikeService.likeEvent(event.getId(), member);
+			em.persist(eventLike);
+
+			Long likeId = eventLike.getId();
+
+			//when //then
+			assertThatThrownBy(() -> eventLikeService.deleteLikeEvent(likeId, loginMember.getId()))
+				.isInstanceOf(AuthenticationRequiredException.class)
+				.hasMessage("인증이 필요합니다");
+		}
+	}
+}


### PR DESCRIPTION
## Description

> 이벤트 좋아요, 좋아요 취소 기능 구현

## Changes

- LikeController
- EventLikeService
- EventLikeServiceTest
- EventLikeRepository 쿼리 추가
- EventLikeRepositoryTest 추가
- 이벤트 좋아요 id(pk)로 EventLike를 찾음
  - EventLike가 없을시 NonExistentEventLikeException
- 이벤트 좋아요 취소시 로그인한 member와 좋아요한 member가 일치하는지 확인
  - 일치하지 않을시 AuthenticationRequiredException 

## ETC
- 사용하지 않는 EventLikeRepository, EventLikeRepositoryTest의 코드 삭제
