### PR TITLE
Feat: #341 - 누락된 @ExceptionHandler 생성

### DIFF
--- a/src/main/java/com/teamddd/duckmap/advice/ArtistAdvice.java
+++ b/src/main/java/com/teamddd/duckmap/advice/ArtistAdvice.java
@@ -1,35 +1,35 @@
 package com.teamddd.duckmap.advice;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.teamddd.duckmap.common.ExceptionCodeMessage;
 import com.teamddd.duckmap.dto.ErrorResult;
-import com.teamddd.duckmap.exception.NotContentTypeImageException;
+import com.teamddd.duckmap.exception.NonExistentArtistException;
+import com.teamddd.duckmap.exception.NonExistentArtistTypeException;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
-public class ApiControllerAdvice {
+public class ArtistAdvice {
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(BindException.class)
-	public ErrorResult bindException(BindException ex) {
+	@ExceptionHandler
+	public ErrorResult nonExistentArtistTypeException(NonExistentArtistTypeException ex) {
 		return ErrorResult.builder()
-			.code(String.valueOf(HttpStatus.BAD_REQUEST))
-			.message(ex.getBindingResult().getAllErrors().get(0).getDefaultMessage())
+			.code(ExceptionCodeMessage.NON_EXISTENT_ARTIST_TYPE_EXCEPTION.code())
+			.message(ex.getMessage())
 			.build();
 	}
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler
-	public ErrorResult notContentTypeImageException(NotContentTypeImageException ex) {
+	public ErrorResult nonExistentArtistException(NonExistentArtistException ex) {
 		return ErrorResult.builder()
-			.code(ExceptionCodeMessage.NOT_CONTENT_TYPE_IMAGE_EXCEPTION.code())
+			.code(ExceptionCodeMessage.NON_EXISTENT_ARTIST_EXCEPTION.code())
 			.message(ex.getMessage())
 			.build();
 	}

--- a/src/main/java/com/teamddd/duckmap/advice/EventAdvice.java
+++ b/src/main/java/com/teamddd/duckmap/advice/EventAdvice.java
@@ -1,36 +1,37 @@
 package com.teamddd.duckmap.advice;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.teamddd.duckmap.common.ExceptionCodeMessage;
 import com.teamddd.duckmap.dto.ErrorResult;
-import com.teamddd.duckmap.exception.NotContentTypeImageException;
+import com.teamddd.duckmap.exception.NonExistentEventCategoryException;
+import com.teamddd.duckmap.exception.NonExistentEventException;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
-public class ApiControllerAdvice {
+public class EventAdvice {
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(BindException.class)
-	public ErrorResult bindException(BindException ex) {
+	@ExceptionHandler
+	public ErrorResult nonExistentEventCategoryException(NonExistentEventCategoryException ex) {
 		return ErrorResult.builder()
-			.code(String.valueOf(HttpStatus.BAD_REQUEST))
-			.message(ex.getBindingResult().getAllErrors().get(0).getDefaultMessage())
+			.code(ExceptionCodeMessage.NON_EXISTENT_EVENT_CATEGORY_EXCEPTION.code())
+			.message(ex.getMessage())
 			.build();
 	}
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler
-	public ErrorResult notContentTypeImageException(NotContentTypeImageException ex) {
+	public ErrorResult nonExistentEventException(NonExistentEventException ex) {
 		return ErrorResult.builder()
-			.code(ExceptionCodeMessage.NOT_CONTENT_TYPE_IMAGE_EXCEPTION.code())
+			.code(ExceptionCodeMessage.NON_EXISTENT_EVENT_EXCEPTION.code())
 			.message(ex.getMessage())
 			.build();
 	}
+
 }


### PR DESCRIPTION
## Description

> 누락된 @ExceptionHandler 생성하여 에러 발생 시 해당 에러코드, 메시지 response 생성 반환

## Changes

- ApiControllerAdvice
  - NotContentTypeImageException
- ArtistAdvice
  - NonExistentArtistTypeException
  - NonExistentArtistTypeException
- EventAdvice
  - NonExistentEventCategoryException
  - NonExistentEventException

## ETC
