### PR TITLE
Feat: #301 - artist, 날짜 기준 리뷰 목록 조회 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
@@ -1,8 +1,10 @@
 package com.teamddd.duckmap.controller;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +25,7 @@ import com.teamddd.duckmap.dto.review.CreateReviewRes;
 import com.teamddd.duckmap.dto.review.MyReviewsRes;
 import com.teamddd.duckmap.dto.review.ReviewRes;
 import com.teamddd.duckmap.dto.review.ReviewSearchParam;
+import com.teamddd.duckmap.dto.review.ReviewSearchServiceReq;
 import com.teamddd.duckmap.dto.review.ReviewsRes;
 import com.teamddd.duckmap.dto.review.UpdateReviewReq;
 import com.teamddd.duckmap.entity.Member;
@@ -67,9 +70,23 @@ public class ReviewController {
 
 	}
 
-	@Operation(summary = "리뷰 목록 조회")
+	@Operation(summary = "리뷰 목록 조회", description = "artist, 날짜 기준 리뷰 목록 조회 기능 구현")
 	@GetMapping
-	public Page<ReviewsRes> getReviews(Pageable pageable, @ModelAttribute ReviewSearchParam reviewSearchParam) {
+	public Page<ReviewRes> getReviews(Pageable pageable, @ModelAttribute ReviewSearchParam reviewSearchParam) {
+		LocalDate today = LocalDate.now();
+
+		ReviewSearchServiceReq request = ReviewSearchServiceReq.builder()
+			.date(today)
+			.artistId(reviewSearchParam.getArtistId())
+			.onlyInProgress(BooleanUtils.isTrue(reviewSearchParam.getOnlyInProgress()))
+			.pageable(pageable)
+			.build();
+		return reviewService.getReviewResList(request);
+	}
+
+	@Operation(summary = "리뷰 이미지 목록 조회", description = "main 화면에 표시되는 리뷰 이미지 목록 조회")
+	@GetMapping("/images")
+	public Page<ReviewsRes> getReviewImages(Pageable pageable) {
 		ImageRes imageRes = ImageRes.builder()
 			.filename("filename.png")
 			.build();

--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchParam.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchParam.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @Builder
 public class ReviewSearchParam {
 	private Long artistId;
-	private boolean inProgress;
+	private boolean onlyInProgress;
 }

--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchParam.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchParam.java
@@ -1,5 +1,6 @@
 package com.teamddd.duckmap.dto.review;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,5 +8,6 @@ import lombok.Getter;
 @Builder
 public class ReviewSearchParam {
 	private Long artistId;
-	private boolean onlyInProgress;
+	@Schema(defaultValue = "false")
+	private Boolean onlyInProgress;
 }

--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchServiceReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchServiceReq.java
@@ -1,0 +1,17 @@
+package com.teamddd.duckmap.dto.review;
+
+import java.time.LocalDate;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewSearchServiceReq {
+	private LocalDate date;
+	private Long artistId;
+	private boolean onlyInProgress;
+	private Pageable pageable;
+}

--- a/src/main/java/com/teamddd/duckmap/service/ReviewService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ReviewService.java
@@ -1,12 +1,15 @@
 package com.teamddd.duckmap.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.review.CreateReviewReq;
 import com.teamddd.duckmap.dto.review.ReviewRes;
+import com.teamddd.duckmap.dto.review.ReviewSearchServiceReq;
 import com.teamddd.duckmap.entity.Event;
 import com.teamddd.duckmap.entity.Member;
 import com.teamddd.duckmap.entity.Review;
@@ -24,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ReviewService {
 
 	private final EventService eventService;
+	private final ArtistService artistService;
 	private final ReviewRepository reviewRepository;
 
 	@Transactional
@@ -50,6 +54,17 @@ public class ReviewService {
 		reviewRepository.save(review);
 
 		return review.getId();
+	}
+
+	public Page<ReviewRes> getReviewResList(ReviewSearchServiceReq request) {
+		if (request.getArtistId() != null) {
+			artistService.getArtist(request.getArtistId());
+		}
+		LocalDate searchDate = request.isOnlyInProgress() ? request.getDate() : null;
+		Page<Review> reviews = reviewRepository.findByArtistAndDate(request.getArtistId(),
+			searchDate, request.getPageable());
+
+		return reviews.map(ReviewRes::of);
 	}
 
 	//Review 단건 조회

--- a/src/test/java/com/teamddd/duckmap/service/ReviewServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/ReviewServiceTest.java
@@ -3,9 +3,13 @@ package com.teamddd.duckmap.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import javax.persistence.EntityManager;
+
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,21 +17,34 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.review.CreateReviewReq;
 import com.teamddd.duckmap.dto.review.ReviewRes;
+import com.teamddd.duckmap.dto.review.ReviewSearchServiceReq;
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.ArtistType;
 import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventArtist;
 import com.teamddd.duckmap.entity.Member;
 import com.teamddd.duckmap.entity.Review;
 import com.teamddd.duckmap.exception.NonExistentReviewException;
+import com.teamddd.duckmap.repository.EventRepository;
 import com.teamddd.duckmap.repository.ReviewRepository;
 
 @Transactional
 @SpringBootTest
 public class ReviewServiceTest {
-
+	@Autowired
+	EntityManager em;
+	@SpyBean
+	EventRepository eventRepository;
+	@MockBean
+	ArtistService artistService;
 	@Autowired
 	ReviewService reviewService;
 	@SpyBean
@@ -117,4 +134,120 @@ public class ReviewServiceTest {
 		}
 	}
 
+	@DisplayName("Artist id, date로 ReviewRes 목록 조회")
+	@Test
+	void getReviewResList() throws Exception {
+		//given
+		LocalDate now = LocalDate.now();
+
+		// save Member
+		Member member1 = Member.builder()
+			.username("member1")
+			.build();
+		Member member2 = Member.builder()
+			.username("member2")
+			.build();
+		em.persist(member1);
+		em.persist(member2);
+
+		// save Artist
+		ArtistType artistType = createArtistType();
+		em.persist(artistType);
+		Artist artist1 = createArtist("artist1", artistType);
+		Artist artist2 = createArtist("artist2", artistType);
+		em.persist(artist1);
+		em.persist(artist2);
+
+		//save Event
+		Event event1 = createEvent(member1, "event1", now.minusDays(2), now.plusDays(1));
+		Event event2 = createEvent(member1, "event2", now.plusDays(1), now.plusDays(1));
+		Event event3 = createEvent(member1, "event3", now.plusDays(1), now.plusDays(1));
+		Event event4 = createEvent(member1, "event4", now.plusDays(1), now.plusDays(3));
+		em.persist(event1);
+		em.persist(event2);
+		em.persist(event3);
+		em.persist(event4);
+
+		// Artist, EventCategory, EventImage -> event
+		EventArtist eventArtist1 = createEventArtist(event1, artist1);
+		EventArtist eventArtist2 = createEventArtist(event2, artist2);
+		EventArtist eventArtist3 = createEventArtist(event3, artist1);
+		EventArtist eventArtist4 = createEventArtist(event4, artist2);
+		em.persist(eventArtist1);
+		em.persist(eventArtist2);
+		em.persist(eventArtist3);
+		em.persist(eventArtist4);
+
+		// save Review
+		Review review1 = createReview(member1, event1, "mem1-review1", 5);
+		Review review2 = createReview(member1, event2, "mem1-review2", 3);
+		Review review3 = createReview(member1, event3, "mem1-review3", 4);
+		Review review4 = createReview(member1, event4, "mem1-review4", 5);
+		Review review5 = createReview(member2, event1, "mem2-review1", 5);
+		Review review6 = createReview(member2, event2, "mem2-review2", 4);
+		Review review7 = createReview(member2, event3, "mem2-review3", 5);
+		Review review8 = createReview(member2, event4, "mem2-review4", 5);
+		em.persist(review1);
+		em.persist(review2);
+		em.persist(review3);
+		em.persist(review4);
+		em.persist(review5);
+		em.persist(review6);
+		em.persist(review7);
+		em.persist(review8);
+
+		em.flush();
+		em.clear();
+
+		Artist searchArtist = artist1;
+
+		Pageable pageable = PageRequest.of(0, 4);
+
+		ReviewSearchServiceReq request = ReviewSearchServiceReq.builder()
+			.date(now)
+			.artistId(searchArtist.getId())
+			.onlyInProgress(false)
+			.pageable(pageable)
+			.build();
+
+		when(artistService.getArtist(any())).thenReturn(searchArtist);
+
+		//when
+		Page<ReviewRes> reviewResList = reviewService.getReviewResList(request);
+
+		//then
+		assertThat(reviewResList).hasSize(4)
+			.extracting("username", "content", "score")
+			.containsExactly(
+				Tuple.tuple("member1", "mem1-review1", 5),
+				Tuple.tuple("member1", "mem1-review3", 4),
+				Tuple.tuple("member2", "mem2-review1", 5),
+				Tuple.tuple("member2", "mem2-review3", 5));
+	}
+
+	ArtistType createArtistType() {
+		return ArtistType.builder().type("artist_type").build();
+	}
+
+	Artist createArtist(String name, ArtistType type) {
+		return Artist.builder().name(name).artistType(type).build();
+	}
+
+	EventArtist createEventArtist(Event event, Artist artist) {
+		return EventArtist.builder().event(event).artist(artist).build();
+	}
+
+	Event createEvent(Member member, String storeName, LocalDate fromDate, LocalDate toDate) {
+		return Event.builder()
+			.member(member)
+			.storeName(storeName)
+			.fromDate(fromDate)
+			.toDate(toDate)
+			.eventImages(List.of())
+			.build();
+	}
+
+	private Review createReview(Member member, Event event, String content, int score) {
+		return Review.builder().member(member).event(event).content(content).score(score).build();
+	}
 }


### PR DESCRIPTION
## Description

> artist, 날짜 기준 리뷰 목록 조회 구현

## Changes

- ReviewController
  - getReviews() 구현: artist, 날짜 기준 리뷰 목록 조회
  - getReviewImages() mockApi로 분리: 기존에 목록 조회가 하나밖에 작성되어 있지 않았음
- ReviewSearchParam의 진행중여부 검색 파라미터 이름 변경 및 타입 변경
- ReviewService
  - getReviewResList 구현
- ReviewServiceTest
  - getReviewResList Test 작성

## ETC
- getReviewImages() 추가 개발 예정