### PR TITLE
Feat: #301 #353 - artist, 날짜 기준 리뷰 목록 조회, 리뷰 이미지 목록 조회 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
@@ -1,8 +1,10 @@
 package com.teamddd.duckmap.controller;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +25,7 @@ import com.teamddd.duckmap.dto.review.CreateReviewRes;
 import com.teamddd.duckmap.dto.review.MyReviewsRes;
 import com.teamddd.duckmap.dto.review.ReviewRes;
 import com.teamddd.duckmap.dto.review.ReviewSearchParam;
+import com.teamddd.duckmap.dto.review.ReviewSearchServiceReq;
 import com.teamddd.duckmap.dto.review.ReviewsRes;
 import com.teamddd.duckmap.dto.review.UpdateReviewReq;
 import com.teamddd.duckmap.entity.Member;
@@ -67,9 +70,23 @@ public class ReviewController {
 
 	}
 
-	@Operation(summary = "리뷰 목록 조회")
+	@Operation(summary = "리뷰 목록 조회", description = "artist, 날짜 기준 리뷰 목록 조회 기능 구현")
 	@GetMapping
-	public Page<ReviewsRes> getReviews(Pageable pageable, @ModelAttribute ReviewSearchParam reviewSearchParam) {
+	public Page<ReviewRes> getReviews(Pageable pageable, @ModelAttribute ReviewSearchParam reviewSearchParam) {
+		LocalDate today = LocalDate.now();
+
+		ReviewSearchServiceReq request = ReviewSearchServiceReq.builder()
+			.date(today)
+			.artistId(reviewSearchParam.getArtistId())
+			.onlyInProgress(BooleanUtils.isTrue(reviewSearchParam.getOnlyInProgress()))
+			.pageable(pageable)
+			.build();
+		return reviewService.getReviewResList(request);
+	}
+
+	@Operation(summary = "리뷰 이미지 목록 조회", description = "main 화면에 표시되는 리뷰 이미지 목록 조회")
+	@GetMapping("/images")
+	public Page<ReviewsRes> getReviewImages(Pageable pageable) {
 		ImageRes imageRes = ImageRes.builder()
 			.filename("filename.png")
 			.build();

--- a/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
@@ -87,26 +87,7 @@ public class ReviewController {
 	@Operation(summary = "리뷰 이미지 목록 조회", description = "main 화면에 표시되는 리뷰 이미지 목록 조회")
 	@GetMapping("/images")
 	public Page<ReviewsRes> getReviewImages(Pageable pageable) {
-		ImageRes imageRes = ImageRes.builder()
-			.filename("filename.png")
-			.build();
-		return new PageImpl<>(List.of(
-			ReviewsRes.builder()
-				.id(1L)
-				.inProgress(false)
-				.image(imageRes)
-				.build(),
-			ReviewsRes.builder()
-				.id(2L)
-				.inProgress(true)
-				.image(imageRes)
-				.build(),
-			ReviewsRes.builder()
-				.id(3L)
-				.inProgress(true)
-				.image(imageRes)
-				.build()
-		));
+		return reviewService.getReviewsResPage(pageable);
 	}
 
 	@Operation(summary = "나의 리뷰 목록 조회")

--- a/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
@@ -72,7 +72,7 @@ public class ReviewController {
 
 	@Operation(summary = "리뷰 목록 조회", description = "artist, 날짜 기준 리뷰 목록 조회 기능 구현")
 	@GetMapping
-	public Page<ReviewRes> getReviews(Pageable pageable, @ModelAttribute ReviewSearchParam reviewSearchParam) {
+	public Page<ReviewsRes> getReviews(Pageable pageable, @ModelAttribute ReviewSearchParam reviewSearchParam) {
 		LocalDate today = LocalDate.now();
 
 		ReviewSearchServiceReq request = ReviewSearchServiceReq.builder()
@@ -81,7 +81,7 @@ public class ReviewController {
 			.onlyInProgress(BooleanUtils.isTrue(reviewSearchParam.getOnlyInProgress()))
 			.pageable(pageable)
 			.build();
-		return reviewService.getReviewResList(request);
+		return reviewService.getReviewsResList(request);
 	}
 
 	@Operation(summary = "리뷰 이미지 목록 조회", description = "main 화면에 표시되는 리뷰 이미지 목록 조회")

--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchParam.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchParam.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @Builder
 public class ReviewSearchParam {
 	private Long artistId;
-	private boolean inProgress;
+	private boolean onlyInProgress;
 }

--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchParam.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchParam.java
@@ -1,5 +1,6 @@
 package com.teamddd.duckmap.dto.review;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,5 +8,6 @@ import lombok.Getter;
 @Builder
 public class ReviewSearchParam {
 	private Long artistId;
-	private boolean onlyInProgress;
+	@Schema(defaultValue = "false")
+	private Boolean onlyInProgress;
 }

--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchServiceReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewSearchServiceReq.java
@@ -1,0 +1,17 @@
+package com.teamddd.duckmap.dto.review;
+
+import java.time.LocalDate;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewSearchServiceReq {
+	private LocalDate date;
+	private Long artistId;
+	private boolean onlyInProgress;
+	private Pageable pageable;
+}

--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewsRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewsRes.java
@@ -16,8 +16,7 @@ public class ReviewsRes {
 	private boolean inProgress;
 	private ImageRes image;
 
-	public static ReviewsRes of(Review review) {
-		LocalDate now = LocalDate.now();
+	public static ReviewsRes of(Review review, LocalDate date) {
 		return ReviewsRes.builder()
 			.id(review.getId())
 			.image(
@@ -29,7 +28,7 @@ public class ReviewsRes {
 							.orElse(null)
 					).build()
 			)
-			.inProgress(review.getEvent().isInProgress(now))
+			.inProgress(review.getEvent().isInProgress(date))
 			.build();
 	}
 

--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewsRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewsRes.java
@@ -1,6 +1,10 @@
 package com.teamddd.duckmap.dto.review;
 
+import java.time.LocalDate;
+
 import com.teamddd.duckmap.dto.ImageRes;
+import com.teamddd.duckmap.entity.Review;
+import com.teamddd.duckmap.entity.ReviewImage;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -11,4 +15,22 @@ public class ReviewsRes {
 	private Long id;
 	private boolean inProgress;
 	private ImageRes image;
+
+	public static ReviewsRes of(Review review) {
+		LocalDate now = LocalDate.now();
+		return ReviewsRes.builder()
+			.id(review.getId())
+			.image(
+				ImageRes.builder()
+					.filename(
+						review.getReviewImages().stream()
+							.map(ReviewImage::getImage)
+							.findFirst()
+							.orElse(null)
+					).build()
+			)
+			.inProgress(review.getEvent().isInProgress(now))
+			.build();
+	}
+
 }

--- a/src/main/java/com/teamddd/duckmap/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/teamddd/duckmap/repository/ReviewRepositoryImpl.java
@@ -38,7 +38,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
 		JPAQuery<Long> countQuery = queryFactory.select(review.count())
 			.from(review)
-			.leftJoin(review.event, event).fetchJoin()
+			.leftJoin(review.event, event)
 			.join(eventArtist).on(event.eq(eventArtist.event))
 			.where(eqArtistId(artistId), betweenDate(date));
 

--- a/src/main/java/com/teamddd/duckmap/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/teamddd/duckmap/repository/ReviewRepositoryImpl.java
@@ -29,7 +29,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 	public Page<Review> findByArtistAndDate(Long artistId, LocalDate date, Pageable pageable) {
 		List<Review> reviews = queryFactory.select(review)
 			.from(review)
-			.leftJoin(review.event, event)
+			.leftJoin(review.event, event).fetchJoin()
 			.join(eventArtist).on(event.eq(eventArtist.event))
 			.where(eqArtistId(artistId), betweenDate(date))
 			.offset(pageable.getOffset())
@@ -38,7 +38,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
 		JPAQuery<Long> countQuery = queryFactory.select(review.count())
 			.from(review)
-			.leftJoin(review.event, event)
+			.leftJoin(review.event, event).fetchJoin()
 			.join(eventArtist).on(event.eq(eventArtist.event))
 			.where(eqArtistId(artistId), betweenDate(date));
 

--- a/src/main/java/com/teamddd/duckmap/service/ReviewService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ReviewService.java
@@ -2,10 +2,8 @@ package com.teamddd.duckmap.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,10 +84,6 @@ public class ReviewService {
 	public Page<ReviewsRes> getReviewsResPage(Pageable pageable) {
 		Page<Review> reviewsPage = reviewRepository.findAll(pageable);
 		LocalDate now = LocalDate.now();
-		List<ReviewsRes> reviewsResList = reviewsPage.getContent().stream()
-			.map(Review -> ReviewsRes.of(Review, now))
-			.collect(Collectors.toList());
-
-		return new PageImpl<>(reviewsResList, reviewsPage.getPageable(), reviewsPage.getTotalElements());
+		return reviewsPage.map(Review -> ReviewsRes.of(Review, now));
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/service/ReviewService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ReviewService.java
@@ -60,7 +60,7 @@ public class ReviewService {
 		return review.getId();
 	}
 
-	public Page<ReviewRes> getReviewResList(ReviewSearchServiceReq request) {
+	public Page<ReviewsRes> getReviewsResList(ReviewSearchServiceReq request) {
 		if (request.getArtistId() != null) {
 			artistService.getArtist(request.getArtistId());
 		}
@@ -68,7 +68,7 @@ public class ReviewService {
 		Page<Review> reviews = reviewRepository.findByArtistAndDate(request.getArtistId(),
 			searchDate, request.getPageable());
 
-		return reviews.map(ReviewRes::of);
+		return reviews.map(ReviewsRes::of);
 	}
 
 	//Review 단건 조회

--- a/src/main/java/com/teamddd/duckmap/service/ReviewService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ReviewService.java
@@ -68,7 +68,7 @@ public class ReviewService {
 		Page<Review> reviews = reviewRepository.findByArtistAndDate(request.getArtistId(),
 			searchDate, request.getPageable());
 
-		return reviews.map(ReviewsRes::of);
+		return reviews.map(Review -> ReviewsRes.of(Review, request.getDate()));
 	}
 
 	//Review 단건 조회
@@ -85,9 +85,9 @@ public class ReviewService {
 
 	public Page<ReviewsRes> getReviewsResPage(Pageable pageable) {
 		Page<Review> reviewsPage = reviewRepository.findAll(pageable);
-
+		LocalDate now = LocalDate.now();
 		List<ReviewsRes> reviewsResList = reviewsPage.getContent().stream()
-			.map(ReviewsRes::of)
+			.map(Review -> ReviewsRes.of(Review, now))
 			.collect(Collectors.toList());
 
 		return new PageImpl<>(reviewsResList, reviewsPage.getPageable(), reviewsPage.getTotalElements());

--- a/src/main/java/com/teamddd/duckmap/service/ReviewService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ReviewService.java
@@ -1,12 +1,15 @@
 package com.teamddd.duckmap.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.review.CreateReviewReq;
 import com.teamddd.duckmap.dto.review.ReviewRes;
+import com.teamddd.duckmap.dto.review.ReviewSearchServiceReq;
 import com.teamddd.duckmap.entity.Event;
 import com.teamddd.duckmap.entity.Member;
 import com.teamddd.duckmap.entity.Review;
@@ -24,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ReviewService {
 
 	private final EventService eventService;
+	private final ArtistService artistService;
 	private final ReviewRepository reviewRepository;
 
 	@Transactional
@@ -50,6 +54,17 @@ public class ReviewService {
 		reviewRepository.save(review);
 
 		return review.getId();
+	}
+
+	public Page<ReviewRes> getReviewResList(ReviewSearchServiceReq request) {
+		if (request.getArtistId() != null) {
+			artistService.getArtist(request.getArtistId());
+		}
+		LocalDate searchDate = request.isOnlyInProgress() ? request.getDate() : null;
+		Page<Review> reviews = reviewRepository.findByArtistAndDate(request.getArtistId(),
+			searchDate, request.getPageable());
+
+		return reviews.map(ReviewRes::of);
 	}
 
 	//Review 단건 조회

--- a/src/main/java/com/teamddd/duckmap/service/ReviewService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ReviewService.java
@@ -2,14 +2,18 @@ package com.teamddd.duckmap.service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.review.CreateReviewReq;
 import com.teamddd.duckmap.dto.review.ReviewRes;
 import com.teamddd.duckmap.dto.review.ReviewSearchServiceReq;
+import com.teamddd.duckmap.dto.review.ReviewsRes;
 import com.teamddd.duckmap.entity.Event;
 import com.teamddd.duckmap.entity.Member;
 import com.teamddd.duckmap.entity.Review;
@@ -79,4 +83,13 @@ public class ReviewService {
 			.orElseThrow(NonExistentReviewException::new);
 	}
 
+	public Page<ReviewsRes> getReviewsResPage(Pageable pageable) {
+		Page<Review> reviewsPage = reviewRepository.findAll(pageable);
+
+		List<ReviewsRes> reviewsResList = reviewsPage.getContent().stream()
+			.map(ReviewsRes::of)
+			.collect(Collectors.toList());
+
+		return new PageImpl<>(reviewsResList, reviewsPage.getPageable(), reviewsPage.getTotalElements());
+	}
 }

--- a/src/test/java/com/teamddd/duckmap/service/ReviewServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/ReviewServiceTest.java
@@ -3,9 +3,13 @@ package com.teamddd.duckmap.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import javax.persistence.EntityManager;
+
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,21 +17,34 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.review.CreateReviewReq;
 import com.teamddd.duckmap.dto.review.ReviewRes;
+import com.teamddd.duckmap.dto.review.ReviewSearchServiceReq;
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.ArtistType;
 import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventArtist;
 import com.teamddd.duckmap.entity.Member;
 import com.teamddd.duckmap.entity.Review;
 import com.teamddd.duckmap.exception.NonExistentReviewException;
+import com.teamddd.duckmap.repository.EventRepository;
 import com.teamddd.duckmap.repository.ReviewRepository;
 
 @Transactional
 @SpringBootTest
 public class ReviewServiceTest {
-
+	@Autowired
+	EntityManager em;
+	@SpyBean
+	EventRepository eventRepository;
+	@MockBean
+	ArtistService artistService;
 	@Autowired
 	ReviewService reviewService;
 	@SpyBean
@@ -117,4 +134,120 @@ public class ReviewServiceTest {
 		}
 	}
 
+	@DisplayName("Artist id, date로 ReviewRes 목록 조회")
+	@Test
+	void getReviewResList() throws Exception {
+		//given
+		LocalDate now = LocalDate.now();
+
+		// save Member
+		Member member1 = Member.builder()
+			.username("member1")
+			.build();
+		Member member2 = Member.builder()
+			.username("member2")
+			.build();
+		em.persist(member1);
+		em.persist(member2);
+
+		// save Artist
+		ArtistType artistType = createArtistType();
+		em.persist(artistType);
+		Artist artist1 = createArtist("artist1", artistType);
+		Artist artist2 = createArtist("artist2", artistType);
+		em.persist(artist1);
+		em.persist(artist2);
+
+		//save Event
+		Event event1 = createEvent(member1, "event1", now.minusDays(2), now.plusDays(1));
+		Event event2 = createEvent(member1, "event2", now.plusDays(1), now.plusDays(1));
+		Event event3 = createEvent(member1, "event3", now.plusDays(1), now.plusDays(1));
+		Event event4 = createEvent(member1, "event4", now.plusDays(1), now.plusDays(3));
+		em.persist(event1);
+		em.persist(event2);
+		em.persist(event3);
+		em.persist(event4);
+
+		// Artist, EventCategory, EventImage -> event
+		EventArtist eventArtist1 = createEventArtist(event1, artist1);
+		EventArtist eventArtist2 = createEventArtist(event2, artist2);
+		EventArtist eventArtist3 = createEventArtist(event3, artist1);
+		EventArtist eventArtist4 = createEventArtist(event4, artist2);
+		em.persist(eventArtist1);
+		em.persist(eventArtist2);
+		em.persist(eventArtist3);
+		em.persist(eventArtist4);
+
+		// save Review
+		Review review1 = createReview(member1, event1, "mem1-review1", 5);
+		Review review2 = createReview(member1, event2, "mem1-review2", 3);
+		Review review3 = createReview(member1, event3, "mem1-review3", 4);
+		Review review4 = createReview(member1, event4, "mem1-review4", 5);
+		Review review5 = createReview(member2, event1, "mem2-review1", 5);
+		Review review6 = createReview(member2, event2, "mem2-review2", 4);
+		Review review7 = createReview(member2, event3, "mem2-review3", 5);
+		Review review8 = createReview(member2, event4, "mem2-review4", 5);
+		em.persist(review1);
+		em.persist(review2);
+		em.persist(review3);
+		em.persist(review4);
+		em.persist(review5);
+		em.persist(review6);
+		em.persist(review7);
+		em.persist(review8);
+
+		em.flush();
+		em.clear();
+
+		Artist searchArtist = artist1;
+
+		Pageable pageable = PageRequest.of(0, 4);
+
+		ReviewSearchServiceReq request = ReviewSearchServiceReq.builder()
+			.date(now)
+			.artistId(searchArtist.getId())
+			.onlyInProgress(false)
+			.pageable(pageable)
+			.build();
+
+		when(artistService.getArtist(any())).thenReturn(searchArtist);
+
+		//when
+		Page<ReviewRes> reviewResList = reviewService.getReviewResList(request);
+
+		//then
+		assertThat(reviewResList).hasSize(4)
+			.extracting("username", "content", "score")
+			.containsExactly(
+				Tuple.tuple("member1", "mem1-review1", 5),
+				Tuple.tuple("member1", "mem1-review3", 4),
+				Tuple.tuple("member2", "mem2-review1", 5),
+				Tuple.tuple("member2", "mem2-review3", 5));
+	}
+
+	ArtistType createArtistType() {
+		return ArtistType.builder().type("artist_type").build();
+	}
+
+	Artist createArtist(String name, ArtistType type) {
+		return Artist.builder().name(name).artistType(type).build();
+	}
+
+	EventArtist createEventArtist(Event event, Artist artist) {
+		return EventArtist.builder().event(event).artist(artist).build();
+	}
+
+	Event createEvent(Member member, String storeName, LocalDate fromDate, LocalDate toDate) {
+		return Event.builder()
+			.member(member)
+			.storeName(storeName)
+			.fromDate(fromDate)
+			.toDate(toDate)
+			.eventImages(List.of())
+			.build();
+	}
+
+	private Review createReview(Member member, Event event, String content, int score) {
+		return Review.builder().member(member).event(event).content(content).score(score).build();
+	}
 }

--- a/src/test/java/com/teamddd/duckmap/service/ReviewServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/ReviewServiceTest.java
@@ -207,9 +207,9 @@ public class ReviewServiceTest {
 				Tuple.tuple(review4.getId(), "/images/image5"));
 	}
 
-	@DisplayName("Artist id, date로 ReviewRes 목록 조회")
+	@DisplayName("Artist id, date로 ReviewsRes 목록 조회")
 	@Test
-	void getReviewResList() throws Exception {
+	void getReviewsResList() throws Exception {
 		//given
 		LocalDate now = LocalDate.now();
 
@@ -256,21 +256,27 @@ public class ReviewServiceTest {
 		Review review2 = createReview(member1, event2, "mem1-review2", 3);
 		Review review3 = createReview(member1, event3, "mem1-review3", 4);
 		Review review4 = createReview(member1, event4, "mem1-review4", 5);
-		Review review5 = createReview(member2, event1, "mem2-review1", 5);
-		Review review6 = createReview(member2, event2, "mem2-review2", 4);
-		Review review7 = createReview(member2, event3, "mem2-review3", 5);
-		Review review8 = createReview(member2, event4, "mem2-review4", 5);
 		em.persist(review1);
 		em.persist(review2);
 		em.persist(review3);
 		em.persist(review4);
-		em.persist(review5);
-		em.persist(review6);
-		em.persist(review7);
-		em.persist(review8);
 
-		em.flush();
-		em.clear();
+		ReviewImage image1 = createReviewImage("image1");
+		ReviewImage image2 = createReviewImage("image2");
+		ReviewImage image3 = createReviewImage("image3");
+		ReviewImage image4 = createReviewImage("image4");
+		ReviewImage image5 = createReviewImage("image5");
+		em.persist(image1);
+		em.persist(image2);
+		em.persist(image3);
+		em.persist(image4);
+		em.persist(image5);
+
+		addReviewImage(review1, image1);
+		addReviewImage(review1, image2);
+		addReviewImage(review2, image3);
+		addReviewImage(review3, image4);
+		addReviewImage(review4, image5);
 
 		Pageable pageable = PageRequest.of(0, 4);
 
@@ -284,16 +290,14 @@ public class ReviewServiceTest {
 		when(artistService.getArtist(any())).thenReturn(artist1);
 
 		//when
-		Page<ReviewRes> reviewResList = reviewService.getReviewResList(request);
+		Page<ReviewsRes> reviewsResList = reviewService.getReviewsResList(request);
 
 		//then
-		assertThat(reviewResList).hasSize(4)
-			.extracting("username", "content", "score")
-			.containsExactly(
-				Tuple.tuple("member1", "mem1-review1", 5),
-				Tuple.tuple("member1", "mem1-review3", 4),
-				Tuple.tuple("member2", "mem2-review1", 5),
-				Tuple.tuple("member2", "mem2-review3", 5));
+		assertThat(reviewsResList).hasSize(2)
+			.extracting("id", "image.fileUrl")
+			.containsExactlyInAnyOrder(
+				Tuple.tuple(review1.getId(), "/images/image1"),
+				Tuple.tuple(review3.getId(), "/images/image4"));
 	}
 
 	ArtistType createArtistType() {


### PR DESCRIPTION
## Description

> artist, 날짜 기준 리뷰 목록 조회, 리뷰 이미지 목록 조회 구현

## Changes

- ReviewController
  - getReviews() 구현: artist, 날짜 기준 리뷰 목록 조회
  - getReviewImages() 구현
- ReviewSearchParam의 진행중여부 검색 파라미터 이름 변경 및 타입 변경
- ReviewService
  - getReviewsResList 구현
  - getReviewsResPage 구현
- ReviewServiceTest
  - getReviewsResList Test 작성
  - getReviewsResPage Test 작성

- fetch join 오류로 인한 ReviewRepositoryImpl 수정 
## ETC
- #301 베이스의 브랜치에서 작업중이었어서 #301의 수정사항을 #353과 커밋을 같이 하게 되었습니다.