### PR TITLE
Feat: #363 - 북마크 폴더 내부의 이벤트 목록 조회 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/BookmarkFolderController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/BookmarkFolderController.java
@@ -1,9 +1,6 @@
 package com.teamddd.duckmap.controller;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,10 +12,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.teamddd.duckmap.dto.ImageRes;
 import com.teamddd.duckmap.dto.event.bookmark.BookmarkFolderMemberRes;
 import com.teamddd.duckmap.dto.event.bookmark.BookmarkFolderRes;
 import com.teamddd.duckmap.dto.event.bookmark.BookmarkedEventRes;
+import com.teamddd.duckmap.dto.event.bookmark.BookmarkedEventsServiceReq;
 import com.teamddd.duckmap.dto.event.bookmark.CreateBookmarkFolderReq;
 import com.teamddd.duckmap.dto.event.bookmark.CreateBookmarkFolderRes;
 import com.teamddd.duckmap.dto.event.bookmark.MyBookmarkFolderServiceReq;
@@ -58,7 +55,7 @@ public class BookmarkFolderController {
 			.pageable(pageable)
 			.build();
 
-		return bookmarkFolderService.getMyBookmarkFolderRes(request);
+		return bookmarkFolderService.getMyBookmarkFolderResList(request);
 	}
 
 	@Operation(summary = "북마크 폴더 pk로 북마크 폴더,사용자 정보 조회", description = "북마크 폴더 외부 공유용 api")
@@ -70,24 +67,11 @@ public class BookmarkFolderController {
 	@Operation(summary = "북마크 폴더 내부의 이벤트 목록 조회")
 	@GetMapping("/{id}/events")
 	public Page<BookmarkedEventRes> getAllBookmarks(@PathVariable Long id, Pageable pageable) {
-		return new PageImpl<>(List.of(
-			BookmarkedEventRes.builder()
-				.id(1L)
-				.storeName("스프링 카페")
-				.image(
-					ImageRes.builder()
-						.filename("default_cafe.jpg")
-						.build()
-				).build(),
-			BookmarkedEventRes.builder()
-				.id(2L)
-				.storeName("썸머 카페")
-				.image(
-					ImageRes.builder()
-						.filename("default_cafe.jpg")
-						.build()
-				).build()
-		));
+		BookmarkedEventsServiceReq request = BookmarkedEventsServiceReq.builder()
+			.bookmarkFolderId(id)
+			.pageable(pageable)
+			.build();
+		return bookmarkFolderService.getBookmarkedEventResList(request);
 	}
 
 	@Operation(summary = "북마크 폴더명, 이미지 변경 요청")

--- a/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkEventDto.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkEventDto.java
@@ -1,19 +1,25 @@
 package com.teamddd.duckmap.dto.event.bookmark;
 
+import java.util.List;
+
 import com.querydsl.core.annotations.QueryProjection;
-import com.teamddd.duckmap.entity.Event;
-import com.teamddd.duckmap.entity.EventBookmark;
+import com.teamddd.duckmap.entity.EventImage;
 
 import lombok.Getter;
 
 @Getter
 public class BookmarkEventDto {
-	private final Event event;
-	private final EventBookmark eventBookmark;
+	private final Long eventId;
+	private final String eventStoreName;
+	private final Long eventBookmarkId;
+	private final List<EventImage> eventImageList;
 
 	@QueryProjection
-	public BookmarkEventDto(Event event, EventBookmark eventBookmark) {
-		this.event = event;
-		this.eventBookmark = eventBookmark;
+	public BookmarkEventDto(Long eventId, String eventStoreName, List<EventImage> eventImageList,
+		Long eventBookmarkId) {
+		this.eventId = eventId;
+		this.eventStoreName = eventStoreName;
+		this.eventImageList = eventImageList;
+		this.eventBookmarkId = eventBookmarkId;
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkEventDto.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkEventDto.java
@@ -1,9 +1,6 @@
 package com.teamddd.duckmap.dto.event.bookmark;
 
-import java.util.List;
-
 import com.querydsl.core.annotations.QueryProjection;
-import com.teamddd.duckmap.entity.EventImage;
 
 import lombok.Getter;
 
@@ -11,15 +8,15 @@ import lombok.Getter;
 public class BookmarkEventDto {
 	private final Long eventId;
 	private final String eventStoreName;
+	private final String eventThumbnail;
 	private final Long eventBookmarkId;
-	private final List<EventImage> eventImageList;
 
 	@QueryProjection
-	public BookmarkEventDto(Long eventId, String eventStoreName, List<EventImage> eventImageList,
+	public BookmarkEventDto(Long eventId, String eventStoreName, String eventThumbnail,
 		Long eventBookmarkId) {
 		this.eventId = eventId;
 		this.eventStoreName = eventStoreName;
-		this.eventImageList = eventImageList;
+		this.eventThumbnail = eventThumbnail;
 		this.eventBookmarkId = eventBookmarkId;
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkedEventRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkedEventRes.java
@@ -1,7 +1,6 @@
 package com.teamddd.duckmap.dto.event.bookmark;
 
 import com.teamddd.duckmap.dto.ImageRes;
-import com.teamddd.duckmap.entity.EventImage;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -22,11 +21,7 @@ public class BookmarkedEventRes {
 			.image(
 				ImageRes.builder()
 					.filename(
-						bookmarkEventDto.getEventImageList().stream()
-							.filter(EventImage::isThumbnail)
-							.map(EventImage::getImage)
-							.findFirst()
-							.orElse(null)
+						bookmarkEventDto.getEventThumbnail()
 					)
 					.build()
 			)

--- a/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkedEventRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkedEventRes.java
@@ -1,6 +1,7 @@
 package com.teamddd.duckmap.dto.event.bookmark;
 
 import com.teamddd.duckmap.dto.ImageRes;
+import com.teamddd.duckmap.entity.EventImage;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,26 @@ import lombok.Getter;
 @Builder
 public class BookmarkedEventRes {
 	private Long id;
+	private Long eventId;
 	private String storeName;
 	private ImageRes image;
+
+	public static BookmarkedEventRes of(BookmarkEventDto bookmarkEventDto) {
+		return BookmarkedEventRes.builder()
+			.id(bookmarkEventDto.getEventBookmarkId())
+			.eventId(bookmarkEventDto.getEventId())
+			.storeName(bookmarkEventDto.getEventStoreName())
+			.image(
+				ImageRes.builder()
+					.filename(
+						bookmarkEventDto.getEventImageList().stream()
+							.filter(EventImage::isThumbnail)
+							.map(EventImage::getImage)
+							.findFirst()
+							.orElse(null)
+					)
+					.build()
+			)
+			.build();
+	}
 }

--- a/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkedEventsServiceReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/bookmark/BookmarkedEventsServiceReq.java
@@ -1,0 +1,13 @@
+package com.teamddd.duckmap.dto.event.bookmark;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class BookmarkedEventsServiceReq {
+	private Long bookmarkFolderId;
+	private Pageable pageable;
+}

--- a/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
+++ b/src/main/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryImpl.java
@@ -32,8 +32,10 @@ public class BookmarkFolderRepositoryImpl implements BookmarkFolderRepositoryCus
 	public Page<BookmarkEventDto> findBookmarkedEvents(Long bookmarkFolderId, Pageable pageable) {
 		List<BookmarkEventDto> events = queryFactory.select(
 				new QBookmarkEventDto(
-					event,
-					eventBookmark
+					event.id,
+					event.storeName,
+					event.eventImages,
+					eventBookmark.id
 				))
 			.from(event)
 			.join(eventBookmark).on(event.eq(eventBookmark.event))

--- a/src/main/java/com/teamddd/duckmap/service/BookmarkFolderService.java
+++ b/src/main/java/com/teamddd/duckmap/service/BookmarkFolderService.java
@@ -5,9 +5,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.ImageRes;
+import com.teamddd.duckmap.dto.event.bookmark.BookmarkEventDto;
 import com.teamddd.duckmap.dto.event.bookmark.BookmarkFolderMemberDto;
 import com.teamddd.duckmap.dto.event.bookmark.BookmarkFolderMemberRes;
 import com.teamddd.duckmap.dto.event.bookmark.BookmarkFolderRes;
+import com.teamddd.duckmap.dto.event.bookmark.BookmarkedEventRes;
+import com.teamddd.duckmap.dto.event.bookmark.BookmarkedEventsServiceReq;
 import com.teamddd.duckmap.dto.event.bookmark.CreateBookmarkFolderReq;
 import com.teamddd.duckmap.dto.event.bookmark.MyBookmarkFolderServiceReq;
 import com.teamddd.duckmap.dto.event.bookmark.UpdateBookmarkFolderReq;
@@ -71,10 +74,17 @@ public class BookmarkFolderService {
 			.orElseThrow(NonExistentBookmarkFolderException::new);
 	}
 
-	public Page<BookmarkFolderRes> getMyBookmarkFolderRes(MyBookmarkFolderServiceReq request) {
+	public Page<BookmarkFolderRes> getMyBookmarkFolderResList(MyBookmarkFolderServiceReq request) {
 		Page<EventBookmarkFolder> myBookmarkFolders = bookmarkFolderRepository.findBookmarkFoldersByMemberId(
 			request.getMemberId(),
 			request.getPageable());
 		return myBookmarkFolders.map(BookmarkFolderRes::of);
+	}
+
+	public Page<BookmarkedEventRes> getBookmarkedEventResList(BookmarkedEventsServiceReq request) {
+		Page<BookmarkEventDto> bookmarkedEvents = bookmarkFolderRepository.findBookmarkedEvents(
+			request.getBookmarkFolderId(),
+			request.getPageable());
+		return bookmarkedEvents.map(BookmarkedEventRes::of);
 	}
 }

--- a/src/test/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/BookmarkFolderRepositoryTest.java
@@ -18,6 +18,7 @@ import com.teamddd.duckmap.dto.event.bookmark.BookmarkFolderMemberDto;
 import com.teamddd.duckmap.entity.Event;
 import com.teamddd.duckmap.entity.EventBookmark;
 import com.teamddd.duckmap.entity.EventBookmarkFolder;
+import com.teamddd.duckmap.entity.EventImage;
 import com.teamddd.duckmap.entity.Member;
 import com.teamddd.duckmap.exception.NonExistentBookmarkFolderException;
 
@@ -95,6 +96,15 @@ public class BookmarkFolderRepositoryTest {
 		em.persist(event3);
 		em.persist(event4);
 
+		EventImage image1 = createEventImage(event, "image1", false);
+		EventImage image2 = createEventImage(event, "image2", true);
+		EventImage image3 = createEventImage(event2, "image3", true);
+		EventImage image4 = createEventImage(event2, "image4", false);
+		em.persist(image1);
+		em.persist(image2);
+		em.persist(image3);
+		em.persist(image4);
+
 		EventBookmarkFolder eventBookmarkFolder = createEventBookmarkFolder(member, "folder1");
 		EventBookmarkFolder eventBookmarkFolder2 = createEventBookmarkFolder(member, "folder2");
 		em.persist(eventBookmarkFolder);
@@ -105,7 +115,6 @@ public class BookmarkFolderRepositoryTest {
 		EventBookmark eventBookmark3 = createEventBookmark(member, event, eventBookmarkFolder2);
 		EventBookmark eventBookmark4 = createEventBookmark(member, event3, eventBookmarkFolder2);
 		EventBookmark eventBookmark5 = createEventBookmark(member, event4, eventBookmarkFolder2);
-
 		em.persist(eventBookmark);
 		em.persist(eventBookmark2);
 		em.persist(eventBookmark3);
@@ -113,26 +122,17 @@ public class BookmarkFolderRepositoryTest {
 		em.persist(eventBookmark5);
 
 		PageRequest pageRequest = PageRequest.of(0, 2);
-		PageRequest pageRequest2 = PageRequest.of(0, 2);
 		//when
 		Page<BookmarkEventDto> bookmarkedEvents = bookmarkFolderRepository
 			.findBookmarkedEvents(eventBookmarkFolder.getId(), pageRequest);
-		Page<BookmarkEventDto> bookmarkedEvents2 = bookmarkFolderRepository
-			.findBookmarkedEvents(eventBookmarkFolder2.getId(), pageRequest2);
 		//then
 		assertThat(bookmarkedEvents).hasSize(2)
-			.extracting("event.id", "event.storeName", "eventBookmark.id")
-			.containsExactly(Tuple.tuple(event.getId(), "event1", eventBookmark.getId()),
-				Tuple.tuple(event2.getId(), "event2", eventBookmark2.getId()));
+			.extracting("eventId", "eventStoreName", "eventBookmarkId", "eventThumbnail")
+			.containsExactly(
+				Tuple.tuple(event.getId(), "event1", eventBookmark.getId(), "image2"),
+				Tuple.tuple(event2.getId(), "event2", eventBookmark2.getId(), "image3"));
 		assertThat(bookmarkedEvents.getTotalElements()).isEqualTo(2);
 		assertThat(bookmarkedEvents.getTotalPages()).isEqualTo(1);
-
-		assertThat(bookmarkedEvents2).hasSize(2)
-			.extracting("event.id", "event.storeName", "eventBookmark.id")
-			.containsExactlyInAnyOrder(Tuple.tuple(event.getId(), "event1", eventBookmark3.getId()),
-				Tuple.tuple(event3.getId(), "event3", eventBookmark4.getId()));
-		assertThat(bookmarkedEvents2.getTotalElements()).isEqualTo(3);
-		assertThat(bookmarkedEvents2.getTotalPages()).isEqualTo(2);
 	}
 
 	private Event createEvent(Member member, String storeName) {
@@ -145,6 +145,14 @@ public class BookmarkFolderRepositoryTest {
 
 	private EventBookmarkFolder createEventBookmarkFolder(Member member, String name) {
 		return EventBookmarkFolder.builder().member(member).name(name).build();
+	}
+
+	EventImage createEventImage(Event event, String image, boolean thumbnail) {
+		return EventImage.builder()
+			.event(event)
+			.image(image)
+			.thumbnail(thumbnail)
+			.build();
 	}
 
 	@DisplayName("북마크 폴더 pk로 북마크 폴더,사용자 정보 조회")


### PR DESCRIPTION
## Description

> 북마크 폴더 내부의 이벤트 목록 조회 구현

## Changes

- BookmarkedEventsServiceReq 생성
- BookmarkedEventRes에 eventId 추가, of() 구현
- BookmarkEventDto에서 필요한 컬럼만 조회하도록 변경
- BookmarkFolderRespositoryImpl
  - findBookmarkedEvents() 에서 필요한 컬럼만 조회
  - image는 thumbnail이 true인 것만 가져옴
- BookmarkFolderService, BookmarkFolderController
  - getBookmarkedEventResList(), getAllBookmarks() 구현
-  BookmarkFolderServiceTest, BookmarkFolderRepositoryTest
  - 쿼리 변경에 따른 테스트 코드 변경 
  - findBookmarkedEvents(), getBookmarkedEvents() 테스트 작성

## ETC
