### PR TITLE
Feat: #372 - 이벤트 pk로 리뷰 목록 조회

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.teamddd.duckmap.dto.review.CreateReviewReq;
 import com.teamddd.duckmap.dto.review.CreateReviewRes;
+import com.teamddd.duckmap.dto.review.EventReviewServiceReq;
+import com.teamddd.duckmap.dto.review.EventReviewsRes;
 import com.teamddd.duckmap.dto.review.MyReviewServiceReq;
 import com.teamddd.duckmap.dto.review.MyReviewsRes;
 import com.teamddd.duckmap.dto.review.ReviewRes;
@@ -98,6 +100,17 @@ public class ReviewController {
 			.build();
 
 		return reviewService.getMyReviewsRes(request);
+	}
+
+	@Operation(summary = "이벤트의 리뷰 목록 조회")
+	@GetMapping("/{eventId}")
+	public Page<EventReviewsRes> getEventReviews(@PathVariable Long eventId, Pageable pageable) {
+		EventReviewServiceReq request = EventReviewServiceReq.builder()
+			.eventId(eventId)
+			.pageable(pageable)
+			.build();
+
+		return reviewService.getEventReviewsResList(request);
 	}
 
 }

--- a/src/main/java/com/teamddd/duckmap/dto/review/EventReviewServiceReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/EventReviewServiceReq.java
@@ -1,0 +1,13 @@
+package com.teamddd.duckmap.dto.review;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class EventReviewServiceReq {
+	private Long eventId;
+	private Pageable pageable;
+}

--- a/src/main/java/com/teamddd/duckmap/dto/review/EventReviewsRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/EventReviewsRes.java
@@ -1,0 +1,46 @@
+package com.teamddd.duckmap.dto.review;
+
+import java.time.LocalDateTime;
+
+import com.teamddd.duckmap.dto.ImageRes;
+import com.teamddd.duckmap.entity.Review;
+import com.teamddd.duckmap.entity.ReviewImage;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EventReviewsRes {
+	private Long id;
+	private ImageRes userProfile;
+	private String username;
+	private LocalDateTime createdAt;
+	private int score;
+	private ImageRes reviewImage;
+	private String content;
+
+	public static EventReviewsRes of(Review review) {
+		return EventReviewsRes.builder()
+			.id(review.getId())
+			.userProfile(
+				ImageRes.builder()
+					.filename(review.getMember().getImage())
+					.build()
+			)
+			.username(review.getMember().getUsername())
+			.createdAt(review.getCreatedAt())
+			.score(review.getScore())
+			.reviewImage(
+				ImageRes.builder()
+					.filename(
+						review.getReviewImages().stream()
+							.map(ReviewImage::getImage)
+							.findFirst()
+							.orElse(null)
+					).build()
+			)
+			.content(review.getContent())
+			.build();
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/repository/ReviewRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/ReviewRepository.java
@@ -17,6 +17,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 
 	Page<Review> findByEvent(Event event, Pageable pageable);
 
+	Page<Review> findByEventId(Long eventId, Pageable pageable);
+
 	@Query("select ROUND(avg(r.score), 1) from Review r where r.event.id = :eventId")
 	Optional<Double> avgScoreByEvent(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/teamddd/duckmap/service/ReviewService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ReviewService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.review.CreateReviewReq;
+import com.teamddd.duckmap.dto.review.EventReviewServiceReq;
+import com.teamddd.duckmap.dto.review.EventReviewsRes;
 import com.teamddd.duckmap.dto.review.MyReviewServiceReq;
 import com.teamddd.duckmap.dto.review.MyReviewsRes;
 import com.teamddd.duckmap.dto.review.ReviewEventDto;
@@ -96,4 +98,9 @@ public class ReviewService {
 		return myEvents.map(MyReviewsRes::of);
 	}
 
+	public Page<EventReviewsRes> getEventReviewsResList(EventReviewServiceReq request) {
+		Page<Review> eventReviews = reviewRepository.findByEventId(request.getEventId(),
+			request.getPageable());
+		return eventReviews.map(EventReviewsRes::of);
+	}
 }

--- a/src/test/java/com/teamddd/duckmap/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/ReviewRepositoryTest.java
@@ -173,10 +173,10 @@ class ReviewRepositoryTest {
 
 		//then
 		assertThat(reviews).hasSize(2)
-			.extracting("id", "content", "review")
+			.extracting("id", "content", "event")
 			.containsExactlyInAnyOrder(
-				Tuple.tuple(review.getId(), review.getContent(), event.getStoreName()),
-				Tuple.tuple(review2.getId(), review2.getContent(), event.getStoreName()));
+				Tuple.tuple(review.getId(), review.getContent(), event),
+				Tuple.tuple(review2.getId(), review2.getContent(), event));
 
 		assertThat(reviews.getTotalElements()).isEqualTo(3);
 		assertThat(reviews.getTotalPages()).isEqualTo(2);

--- a/src/test/java/com/teamddd/duckmap/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/ReviewRepositoryTest.java
@@ -145,6 +145,43 @@ class ReviewRepositoryTest {
 		assertThat(reviews2.getTotalPages()).isEqualTo(1);
 	}
 
+	@DisplayName("EventId로 review 목록 조회")
+	@Test
+	void findByEventId() throws Exception {
+		//given
+		Member member1 = Member.builder().username("user1").build();
+		Member member2 = Member.builder().username("user2").build();
+		Member member3 = Member.builder().username("user3").build();
+		em.persist(member1);
+		em.persist(member2);
+		em.persist(member3);
+
+		Event event = createEvent("event1");
+		em.persist(event);
+
+		Review review = createReview(member1, event, "user1 review1", 5);
+		Review review2 = createReview(member2, event, "user2 review1", 5);
+		Review review3 = createReview(member3, event, "user3 review1", 5);
+		em.persist(review);
+		em.persist(review2);
+		em.persist(review3);
+
+		PageRequest pageRequest = PageRequest.of(0, 2);
+
+		//when
+		Page<Review> reviews = reviewRepository.findByEventId(event.getId(), pageRequest);
+
+		//then
+		assertThat(reviews).hasSize(2)
+			.extracting("id", "content", "review")
+			.containsExactlyInAnyOrder(
+				Tuple.tuple(review.getId(), review.getContent(), event.getStoreName()),
+				Tuple.tuple(review2.getId(), review2.getContent(), event.getStoreName()));
+
+		assertThat(reviews.getTotalElements()).isEqualTo(3);
+		assertThat(reviews.getTotalPages()).isEqualTo(2);
+	}
+
 	@DisplayName("MemberId로 my review 목록 조회, Dto 반환")
 	@Test
 	void findWithEventByMemberId() throws Exception {


### PR DESCRIPTION
## Description

> 이벤트 pk로 리뷰 목록 조회

## Changes

- EventReviewServiceReq, EventReviewsRes 생성
- ReviewRepository : findByEventId() 추가
- ReviewService, ReviewController
  - 이벤트의 리뷰 목록 조회하는 getEventReviews() 구현 
- ReviewRepositoryTest, ReviewServiceTest
  - findByEventId(), getEventReviewsResList() Test 코드 작성
    - 불필요한 em.flush(), em.clear() 제거
    - 각 테스트에 reviewImage 확인 추가


## ETC
