### PR TITLE
Feat: #411 - 회원 탈퇴시 이벤트 좋아요, 마지막 검색 아티스트 삭제

### DIFF
--- a/src/main/java/com/teamddd/duckmap/repository/EventLikeRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/EventLikeRepository.java
@@ -1,9 +1,16 @@
 package com.teamddd.duckmap.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.teamddd.duckmap.entity.EventLike;
 
 public interface EventLikeRepository extends JpaRepository<EventLike, Long> {
 	Long countByEventId(Long eventId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("delete from EventLike el where el.member.id = :memberId")
+	int deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/teamddd/duckmap/repository/LastSearchArtistRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/LastSearchArtistRepository.java
@@ -15,4 +15,9 @@ public interface LastSearchArtistRepository extends JpaRepository<LastSearchArti
 	@Modifying(clearAutomatically = true)
 	@Query("delete from LastSearchArtist lsa where lsa.artist.id = :artistId")
 	int deleteByArtistId(@Param("artistId") Long artistId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("delete from LastSearchArtist lsa where lsa.member.id = :memberId")
+	int deleteByMemberId(@Param("memberId") Long memberId);
+
 }

--- a/src/main/java/com/teamddd/duckmap/service/MemberService.java
+++ b/src/main/java/com/teamddd/duckmap/service/MemberService.java
@@ -15,6 +15,8 @@ import com.teamddd.duckmap.exception.DuplicateUsernameException;
 import com.teamddd.duckmap.exception.InvalidMemberException;
 import com.teamddd.duckmap.exception.InvalidPasswordException;
 import com.teamddd.duckmap.exception.InvalidUuidException;
+import com.teamddd.duckmap.repository.EventLikeRepository;
+import com.teamddd.duckmap.repository.LastSearchArtistRepository;
 import com.teamddd.duckmap.repository.MemberRepository;
 import com.teamddd.duckmap.util.FileUtils;
 import com.teamddd.duckmap.util.MemberUtils;
@@ -27,6 +29,8 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 	private final Props props;
 	private final MemberRepository memberRepository;
+	private final EventLikeRepository eventLikeRepository;
+	private final LastSearchArtistRepository lastSearchArtistRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final RedisService redisService;
 
@@ -97,6 +101,11 @@ public class MemberService {
 		if (StringUtils.hasText(member.getImage())) {
 			FileUtils.deleteFile(props.getImageDir(), member.getImage());
 		}
+
+		//마지막 검색 아티스트 삭제
+		lastSearchArtistRepository.deleteByMemberId(id);
+		//좋아요 삭제
+		eventLikeRepository.deleteByMemberId(id);
 
 		memberRepository.deleteById(id);
 	}

--- a/src/test/java/com/teamddd/duckmap/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/BookmarkRepositoryTest.java
@@ -2,6 +2,7 @@ package com.teamddd.duckmap.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.persistence.EntityManager;
@@ -44,18 +45,19 @@ public class BookmarkRepositoryTest {
 
 		EventBookmark eventBookmark = createEventBookmark(member, event, eventBookmarkFolder);
 		EventBookmark eventBookmark2 = createEventBookmark(member, event2, eventBookmarkFolder2);
-
+		EventBookmark eventBookmark3 = createEventBookmark(member, event2, eventBookmarkFolder);
 		em.persist(eventBookmark);
 		em.persist(eventBookmark2);
+		em.persist(eventBookmark3);
 
 		//when
-		bookmarkRepository.deleteByBookmarkFolderId(eventBookmarkFolder.getId());
+		int deleteCount = bookmarkRepository.deleteByBookmarkFolderId(eventBookmarkFolder.getId());
 
 		//then
-		Optional<EventBookmark> findBookmark = bookmarkRepository.findByEventIdAndMemberId(event.getId(),
-			member.getId());
-		assertThat(findBookmark).isEmpty();
+		assertThat(deleteCount).isEqualTo(2);
 
+		List<EventBookmark> findBookmark = bookmarkRepository.findAll();
+		assertThat(findBookmark).hasSize(1);
 	}
 
 	@DisplayName("eventId와 memberId로 북마크 조회")

--- a/src/test/java/com/teamddd/duckmap/repository/EventLikeRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/EventLikeRepositoryTest.java
@@ -2,8 +2,11 @@ package com.teamddd.duckmap.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import javax.persistence.EntityManager;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -59,6 +62,46 @@ public class EventLikeRepositoryTest {
 		assertThat(likeCount2).isEqualTo(1);
 		assertThat(likeCount3).isEqualTo(1);
 
+	}
+
+	@DisplayName("Member Id로 EventLike 삭제")
+	@Test
+	void deleteByMemberId() throws Exception {
+		//given
+		Member member1 = Member.builder().build();
+		Member member2 = Member.builder().build();
+		Member member3 = Member.builder().build();
+		em.persist(member1);
+		em.persist(member2);
+		em.persist(member3);
+
+		Event event1 = createEvent(member1, "event1");
+		Event event2 = createEvent(member1, "event2");
+		Event event3 = createEvent(member1, "event3");
+		em.persist(event1);
+		em.persist(event2);
+		em.persist(event3);
+
+		EventLike eventLike1 = createEventLike(member1, event1);
+		EventLike eventLike2 = createEventLike(member1, event2);
+		EventLike eventLike3 = createEventLike(member2, event1);
+		EventLike eventLike4 = createEventLike(member2, event3);
+		EventLike eventLike5 = createEventLike(member3, event1);
+
+		em.persist(eventLike1);
+		em.persist(eventLike2);
+		em.persist(eventLike3);
+		em.persist(eventLike4);
+		em.persist(eventLike5);
+
+		//when
+		int deleteCount = eventLikeRepository.deleteByMemberId(member1.getId());
+
+		//then
+		assertThat(deleteCount).isEqualTo(2);
+
+		List<EventLike> findEventLike = eventLikeRepository.findAll();
+		assertThat(findEventLike).hasSize(3);
 	}
 
 	private Event createEvent(Member member, String storeName) {

--- a/src/test/java/com/teamddd/duckmap/repository/LastSearchArtistRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/LastSearchArtistRepositoryTest.java
@@ -52,6 +52,37 @@ class LastSearchArtistRepositoryTest {
 		assertThat(findLastSearchArtists).hasSize(0);
 	}
 
+	@DisplayName("Member Id로 LastSearchArtist 목록 삭제")
+	@Test
+	void deleteByMemberId() throws Exception {
+		//given
+		Member member1 = createMember("member1");
+		em.persist(member1);
+
+		Artist artist1 = createArtist("artist1");
+		Artist artist2 = createArtist("artist2");
+		Artist artist3 = createArtist("artist3");
+		em.persist(artist1);
+		em.persist(artist2);
+		em.persist(artist3);
+
+		LastSearchArtist lastSearchArtist1 = createLastSearchArtist(member1, artist1);
+		LastSearchArtist lastSearchArtist2 = createLastSearchArtist(member1, artist2);
+		LastSearchArtist lastSearchArtist3 = createLastSearchArtist(member1, artist3);
+		em.persist(lastSearchArtist1);
+		em.persist(lastSearchArtist2);
+		em.persist(lastSearchArtist3);
+
+		//when
+		int deleteCount = lastSearchArtistRepository.deleteByMemberId(member1.getId());
+
+		//then
+		assertThat(deleteCount).isEqualTo(3);
+
+		List<LastSearchArtist> findLastSearchArtists = lastSearchArtistRepository.findAll();
+		assertThat(findLastSearchArtists).hasSize(0);
+	}
+
 	Member createMember(String email) {
 		return Member.builder()
 			.email(email)

--- a/src/test/java/com/teamddd/duckmap/service/MemberServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/MemberServiceTest.java
@@ -2,7 +2,10 @@ package com.teamddd.duckmap.service;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
+
+import javax.persistence.EntityManager;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,17 +15,28 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.user.CreateMemberReq;
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventLike;
+import com.teamddd.duckmap.entity.LastSearchArtist;
 import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.repository.EventLikeRepository;
+import com.teamddd.duckmap.repository.LastSearchArtistRepository;
 import com.teamddd.duckmap.repository.MemberRepository;
 
 @SpringBootTest
 @Transactional
 public class MemberServiceTest {
-
+	@Autowired
+	EntityManager em;
 	@Autowired
 	MemberService memberService;
 	@Autowired
 	MemberRepository memberRepository;
+	@Autowired
+	LastSearchArtistRepository lastSearchArtistRepository;
+	@Autowired
+	EventLikeRepository eventLikeRepository;
 
 	@DisplayName("생성된 회원 확인")
 	@Test
@@ -37,8 +51,84 @@ public class MemberServiceTest {
 		//then
 		assertThat(memberId).isNotNull();
 		Optional<Member> findMember = memberRepository.findById(memberId);
+		assertThat(findMember).isNotEmpty();
 		assertThat(findMember.get())
 			.extracting("username")
 			.isEqualTo("user1");
+	}
+
+	@DisplayName("회원 탈퇴시 이벤트좋아요, 마지막검색 아티스트도 삭제")
+	@Test
+	void deleteMember() throws Exception {
+		//given
+		Member member1 = Member.builder().build();
+		Member member2 = Member.builder().build();
+		em.persist(member1);
+		em.persist(member2);
+
+		Event event1 = createEvent(member1, "event1");
+		Event event2 = createEvent(member1, "event2");
+		Event event3 = createEvent(member1, "event3");
+		em.persist(event1);
+		em.persist(event2);
+		em.persist(event3);
+
+		EventLike eventLike1 = createEventLike(member1, event1);
+		EventLike eventLike2 = createEventLike(member1, event2);
+		EventLike eventLike3 = createEventLike(member2, event1);
+		EventLike eventLike4 = createEventLike(member2, event3);
+		em.persist(eventLike1);
+		em.persist(eventLike2);
+		em.persist(eventLike3);
+		em.persist(eventLike4);
+
+		Artist artist1 = createArtist("artist1");
+		Artist artist2 = createArtist("artist2");
+		Artist artist3 = createArtist("artist3");
+		em.persist(artist1);
+		em.persist(artist2);
+		em.persist(artist3);
+
+		LastSearchArtist lastSearchArtist1 = createLastSearchArtist(member1, artist1);
+		LastSearchArtist lastSearchArtist2 = createLastSearchArtist(member1, artist2);
+		LastSearchArtist lastSearchArtist3 = createLastSearchArtist(member2, artist3);
+		em.persist(lastSearchArtist1);
+		em.persist(lastSearchArtist2);
+		em.persist(lastSearchArtist3);
+
+		//when
+		memberService.deleteMember(member1.getId());
+
+		//then
+		Optional<Member> findMember = memberRepository.findById(member1.getId());
+		assertThat(findMember).isEmpty();
+		List<EventLike> findEventLike = eventLikeRepository.findAll();
+		assertThat(findEventLike).hasSize(2);
+		List<LastSearchArtist> findLateSearchArtist = lastSearchArtistRepository.findAll();
+		assertThat(findLateSearchArtist).hasSize(1);
+	}
+
+	private Event createEvent(Member member, String storeName) {
+		return Event.builder().member(member).storeName(storeName).build();
+	}
+
+	private EventLike createEventLike(Member member, Event event) {
+		return EventLike.builder().member(member).event(event).build();
+	}
+
+	Artist createArtist(String name) {
+		return Artist.builder()
+			.group(null)
+			.artistType(null)
+			.image("image")
+			.name(name)
+			.build();
+	}
+
+	LastSearchArtist createLastSearchArtist(Member member, Artist artist) {
+		return LastSearchArtist.builder()
+			.member(member)
+			.artist(artist)
+			.build();
 	}
 }


### PR DESCRIPTION
## Description

> 회원 탈퇴시 이벤트 좋아요, 마지막 검색 아티스트 삭제

## Changes

- MemberService의 deleteMember() 로직 수정
- MemberServiceTest 작성
- EventLikeRepository, LastSearchArtistRepository 
  - deleteByMemberId() 구현
- EventLikeRepositoryTest, LastSearchArtistRepositoryTest 
  - deleteByMemberId() 테스트 코드 작성
- BookmarkRepositoryTest
  - deleteByBookmarkFolderId() 테스트 코드 수정 

## ETC
