### PR TITLE
Feat: #430 - event 삭제 기능 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -80,6 +80,9 @@ public class EventController {
 	@Operation(summary = "이벤트 삭제")
 	@DeleteMapping("/{id}")
 	public void deleteEvent(@PathVariable Long id) {
+		Member member = MemberUtils.getAuthMember().getUser();
+
+		eventService.deleteEvent(member.getId(), id);
 	}
 
 	@Operation(summary = "이벤트 목록 조회")

--- a/src/main/java/com/teamddd/duckmap/entity/Event.java
+++ b/src/main/java/com/teamddd/duckmap/entity/Event.java
@@ -44,15 +44,15 @@ public class Event extends BaseTimeEntity {
 	private Member member;
 
 	@Builder.Default
-	@OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "event", cascade = CascadeType.PERSIST)
 	private List<EventArtist> eventArtists = new ArrayList<>();
 
 	@Builder.Default
-	@OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "event", cascade = CascadeType.PERSIST)
 	private List<EventInfoCategory> eventInfoCategories = new ArrayList<>();
 
 	@Builder.Default
-	@OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "event", cascade = CascadeType.PERSIST)
 	private List<EventImage> eventImages = new ArrayList<>();
 
 	public boolean isInProgress(LocalDate date) {

--- a/src/main/java/com/teamddd/duckmap/repository/EventBookmarkRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/EventBookmarkRepository.java
@@ -5,12 +5,10 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.teamddd.duckmap.entity.EventLike;
+import com.teamddd.duckmap.entity.EventBookmark;
 
-public interface EventLikeRepository extends JpaRepository<EventLike, Long> {
-	Long countByEventId(Long eventId);
-
+public interface EventBookmarkRepository extends JpaRepository<EventBookmark, Long> {
 	@Modifying
-	@Query("delete from EventLike el where el.event.id = :eventId")
+	@Query("delete from EventBookmark eb where eb.event.id = :eventId")
 	int deleteByEventId(@Param("eventId") Long eventId);
 }

--- a/src/test/java/com/teamddd/duckmap/repository/EventBookmarkRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/EventBookmarkRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.teamddd.duckmap.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventBookmark;
+import com.teamddd.duckmap.entity.Member;
+
+@SpringBootTest
+@Transactional
+class EventBookmarkRepositoryTest {
+	@Autowired
+	EventBookmarkRepository eventBookmarkRepository;
+	@Autowired
+	EntityManager em;
+
+	@DisplayName("Event fk로 EventBookmark 목록을 삭제한다")
+	@Test
+	void deleteById() throws Exception {
+		//given
+		Event event1 = createEvent(null, "event1");
+		em.persist(event1);
+
+		EventBookmark eventBookmark1 = createEventBookmark(null, null);
+		EventBookmark eventBookmark2 = createEventBookmark(null, event1);
+		EventBookmark eventBookmark3 = createEventBookmark(null, event1);
+		em.persist(eventBookmark1);
+		em.persist(eventBookmark2);
+		em.persist(eventBookmark3);
+
+		em.flush();
+		em.clear();
+
+		//when
+		int count = eventBookmarkRepository.deleteByEventId(event1.getId());
+
+		em.flush();
+		em.clear();
+
+		//then
+		assertThat(count).isEqualTo(2);
+
+		List<EventBookmark> findEventBookmarks = eventBookmarkRepository.findAll();
+		assertThat(findEventBookmarks).hasSize(1)
+			.extracting("id")
+			.containsExactly(eventBookmark1.getId());
+	}
+
+	private Event createEvent(Member member, String storeName) {
+		return Event.builder().member(member).storeName(storeName).build();
+	}
+
+	private EventBookmark createEventBookmark(Member member, Event event) {
+		return EventBookmark.builder().member(member).event(event).build();
+	}
+}

--- a/src/test/java/com/teamddd/duckmap/repository/EventLikeRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/EventLikeRepositoryTest.java
@@ -2,8 +2,11 @@ package com.teamddd.duckmap.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import javax.persistence.EntityManager;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,7 +18,7 @@ import com.teamddd.duckmap.entity.Member;
 
 @SpringBootTest
 @Transactional
-public class EventLikeRepositoryTest {
+class EventLikeRepositoryTest {
 	@Autowired
 	EventLikeRepository eventLikeRepository;
 	@Autowired
@@ -59,6 +62,38 @@ public class EventLikeRepositoryTest {
 		assertThat(likeCount2).isEqualTo(1);
 		assertThat(likeCount3).isEqualTo(1);
 
+	}
+
+	@DisplayName("Event fk로 EventLike 목록을 삭제한다")
+	@Test
+	void deleteById() throws Exception {
+		//given
+		Event event1 = createEvent(null, "event1");
+		em.persist(event1);
+
+		EventLike eventLike1 = createEventLike(null, event1);
+		EventLike eventLike2 = createEventLike(null, null);
+		EventLike eventLike3 = createEventLike(null, event1);
+		em.persist(eventLike1);
+		em.persist(eventLike2);
+		em.persist(eventLike3);
+
+		em.flush();
+		em.clear();
+
+		//when
+		int count = eventLikeRepository.deleteByEventId(event1.getId());
+
+		em.flush();
+		em.clear();
+
+		//then
+		assertThat(count).isEqualTo(2);
+
+		List<EventLike> findEventLikes = eventLikeRepository.findAll();
+		assertThat(findEventLikes).hasSize(1)
+			.extracting("id")
+			.containsExactly(eventLike2.getId());
 	}
 
 	private Event createEvent(Member member, String storeName) {


### PR DESCRIPTION
## Description

> event 삭제 기능 구현

## Changes

- Event
  - Event cascade.REMOVE, orphanRemoval 는 delete query가 n번 발생해서 bulk로 대체
- EventService deleteEvent()
  - EventLikeRepository deleteByEventId()
  - EventBookmarkRepository deleteByEventId()
- EventController deleteEvent()

## ETC
