### PR TITLE
Feat: #422 - 지도 표기용 Event 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -21,9 +21,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.teamddd.duckmap.dto.PageReq;
 import com.teamddd.duckmap.dto.event.event.CreateEventReq;
 import com.teamddd.duckmap.dto.event.event.CreateEventRes;
+import com.teamddd.duckmap.dto.event.event.EventPageReq;
 import com.teamddd.duckmap.dto.event.event.EventRes;
 import com.teamddd.duckmap.dto.event.event.EventSearchParam;
 import com.teamddd.duckmap.dto.event.event.EventSearchServiceReq;
+import com.teamddd.duckmap.dto.event.event.EventsMapRes;
 import com.teamddd.duckmap.dto.event.event.EventsRes;
 import com.teamddd.duckmap.dto.event.event.HashtagRes;
 import com.teamddd.duckmap.dto.event.event.MyEventsServiceReq;
@@ -136,6 +138,14 @@ public class EventController {
 			.build();
 
 		return eventService.getMyLikeEventsRes(request);
+	}
+
+	@Operation(summary = "지도 표기용 이벤트 목록 조회")
+	@GetMapping("/map")
+	public Page<EventsMapRes> getEventsForMap(EventPageReq pageable) {
+		LocalDate now = LocalDate.now();
+
+		return eventService.getEventsForMap(now, pageable.toPageable());
 	}
 
 	@Operation(summary = "오늘 진행중인 이벤트 해시태그 목록 조회")

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventLikeReviewCountDto.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventLikeReviewCountDto.java
@@ -1,0 +1,20 @@
+package com.teamddd.duckmap.dto.event.event;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.teamddd.duckmap.entity.Event;
+
+import lombok.Getter;
+
+@Getter
+public class EventLikeReviewCountDto {
+	private Event event;
+	private Long likeCount;
+	private Long reviewCount;
+
+	@QueryProjection
+	public EventLikeReviewCountDto(Event event, Long likeCount, Long reviewCount) {
+		this.event = event;
+		this.likeCount = likeCount;
+		this.reviewCount = reviewCount;
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventPageReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventPageReq.java
@@ -1,0 +1,36 @@
+package com.teamddd.duckmap.dto.event.event;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class EventPageReq {
+	@Schema(defaultValue = "0")
+	private Integer page;
+
+	@Schema(defaultValue = "20")
+	private Integer size;
+
+	@Schema(defaultValue = "DESC")
+	private Sort.Direction direction;
+
+	@Schema(defaultValue = "likeCount", description = "likeCount: 좋아요수, reviewCount: 리뷰수")
+	private String sortProperty;
+
+	@Builder
+	public EventPageReq(Integer page, Integer size, Sort.Direction direction, String sortProperty) {
+		this.page = page == null ? 0 : page;
+		this.size = size == null ? 20 : size;
+		this.direction = direction == null ? Sort.Direction.DESC : direction;
+		this.sortProperty = sortProperty == null ? "likeCount" : sortProperty;
+	}
+
+	public Pageable toPageable() {
+		return PageRequest.of(page, size, Sort.by(direction, sortProperty));
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventsMapRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventsMapRes.java
@@ -1,0 +1,34 @@
+package com.teamddd.duckmap.dto.event.event;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.EventArtist;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EventsMapRes {
+	private Long id;
+	private String storeName;
+	private Long likeCount;
+	private Long reviewCount;
+	private List<String> artists;
+
+	public static EventsMapRes of(EventLikeReviewCountDto dto) {
+		return EventsMapRes.builder()
+			.storeName(dto.getEvent().getStoreName())
+			.likeCount(dto.getLikeCount())
+			.reviewCount(dto.getReviewCount())
+			.artists(
+				dto.getEvent().getEventArtists().stream()
+					.map(EventArtist::getArtist)
+					.map(Artist::getName)
+					.collect(Collectors.toList())
+			)
+			.build();
+	}
+}

--- a/src/main/java/com/teamddd/duckmap/entity/EventArtist.java
+++ b/src/main/java/com/teamddd/duckmap/entity/EventArtist.java
@@ -1,7 +1,9 @@
 package com.teamddd.duckmap.entity;
 
+import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -29,6 +31,6 @@ public class EventArtist extends BaseTimeEntity {
 	private Event event;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "artist_id")
+	@JoinColumn(name = "artist_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 	private Artist artist;
 }

--- a/src/main/java/com/teamddd/duckmap/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/teamddd/duckmap/repository/EventRepositoryCustom.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.teamddd.duckmap.dto.event.event.EventLikeBookmarkDto;
+import com.teamddd.duckmap.dto.event.event.EventLikeReviewCountDto;
 
 public interface EventRepositoryCustom {
 
@@ -17,4 +18,6 @@ public interface EventRepositoryCustom {
 	Page<EventLikeBookmarkDto> findMyLikeEvents(Long memberId, Pageable pageable);
 
 	Page<EventLikeBookmarkDto> findByArtistAndDate(Long artistId, LocalDate date, Long memberId, Pageable pageable);
+
+	Page<EventLikeReviewCountDto> findForMap(LocalDate date, Pageable pageable);
 }

--- a/src/main/java/com/teamddd/duckmap/service/EventService.java
+++ b/src/main/java/com/teamddd/duckmap/service/EventService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -16,8 +17,10 @@ import com.teamddd.duckmap.dto.artist.ArtistRes;
 import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
 import com.teamddd.duckmap.dto.event.event.CreateEventReq;
 import com.teamddd.duckmap.dto.event.event.EventLikeBookmarkDto;
+import com.teamddd.duckmap.dto.event.event.EventLikeReviewCountDto;
 import com.teamddd.duckmap.dto.event.event.EventRes;
 import com.teamddd.duckmap.dto.event.event.EventSearchServiceReq;
+import com.teamddd.duckmap.dto.event.event.EventsMapRes;
 import com.teamddd.duckmap.dto.event.event.EventsRes;
 import com.teamddd.duckmap.dto.event.event.MyEventsServiceReq;
 import com.teamddd.duckmap.dto.event.event.MyLikeEventsServiceReq;
@@ -182,6 +185,12 @@ public class EventService {
 			request.getPageable());
 
 		return myLikeEvents.map(eventLikeBookmarkDto -> EventsRes.of(eventLikeBookmarkDto, request.getDate()));
+	}
+
+	public Page<EventsMapRes> getEventsForMap(LocalDate date, Pageable pageable) {
+		Page<EventLikeReviewCountDto> events = eventRepository.findForMap(date, pageable);
+
+		return events.map(EventsMapRes::of);
 	}
 
 	@Transactional

--- a/src/test/java/com/teamddd/duckmap/service/EventServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/EventServiceTest.java
@@ -19,12 +19,14 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.teamddd.duckmap.dto.event.event.CreateEventReq;
 import com.teamddd.duckmap.dto.event.event.EventRes;
 import com.teamddd.duckmap.dto.event.event.EventSearchServiceReq;
+import com.teamddd.duckmap.dto.event.event.EventsMapRes;
 import com.teamddd.duckmap.dto.event.event.EventsRes;
 import com.teamddd.duckmap.dto.event.event.MyEventsServiceReq;
 import com.teamddd.duckmap.dto.event.event.MyLikeEventsServiceReq;
@@ -39,6 +41,7 @@ import com.teamddd.duckmap.entity.EventImage;
 import com.teamddd.duckmap.entity.EventInfoCategory;
 import com.teamddd.duckmap.entity.EventLike;
 import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.entity.Review;
 import com.teamddd.duckmap.entity.Role;
 import com.teamddd.duckmap.repository.EventInfoCategoryRepository;
 import com.teamddd.duckmap.repository.EventLikeRepository;
@@ -430,6 +433,89 @@ class EventServiceTest {
 				Tuple.tuple("event4", eventLike3.getId()));
 	}
 
+	@DisplayName("좋아요, 리뷰 수로 정렬하여 EventsMapRes 목록 조회한다")
+	@Test
+	void getEventsForMap() throws Exception {
+		//given
+		LocalDate now = LocalDate.now();
+
+		Event event1 = createEvent(null, "event1", now.minusDays(2), now.minusDays(1), null);
+		Event event2 = createEvent(null, "event2", now.minusDays(2), now, null);
+		Event event3 = createEvent(null, "event3", now.minusDays(1), now, null);
+		Event event4 = createEvent(null, "event4", now.minusDays(1), now.plusDays(1), null);
+		Event event5 = createEvent(null, "event5", now.minusDays(1), now.plusDays(2), null);
+		Event event6 = createEvent(null, "event6", now, now.plusDays(2), null);
+		eventRepository.saveAll(List.of(event1, event2, event3, event4, event5, event6));
+
+		Artist artist1 = createArtist("artist1", null);
+		Artist artist2 = createArtist("artist2", null);
+		em.persist(artist1);
+		em.persist(artist2);
+
+		EventArtist eventArtist1 = createEventArtist(event1, artist1);
+		EventArtist eventArtist2 = createEventArtist(event2, artist1);
+		EventArtist eventArtist3 = createEventArtist(event3, artist2);
+		EventArtist eventArtist4 = createEventArtist(event4, artist2);
+		EventArtist eventArtist5 = createEventArtist(event5, artist1);
+		EventArtist eventArtist6 = createEventArtist(event6, Artist.builder().id(100L).build());
+		em.persist(eventArtist1);
+		em.persist(eventArtist2);
+		em.persist(eventArtist3);
+		em.persist(eventArtist4);
+		em.persist(eventArtist5);
+		em.persist(eventArtist6);
+
+		for (int i = 0; i < 2; i++) {
+			em.persist(createEventLike(event1, null));
+		}
+		for (int i = 0; i < 8; i++) {
+			em.persist(createEventLike(event2, null));
+		}
+		for (int i = 0; i < 4; i++) {
+			em.persist(createEventLike(event3, null));
+		}
+		for (int i = 0; i < 10; i++) {
+			em.persist(createEventLike(event4, null));
+		}
+		for (int i = 0; i < 6; i++) {
+			em.persist(createEventLike(event5, null));
+		}
+		for (int i = 0; i < 12; i++) {
+			em.persist(createEventLike(event6, null));
+		}
+
+		for (int i = 0; i < 11; i++) {
+			em.persist(createReview(event1));
+		}
+		for (int i = 0; i < 5; i++) {
+			em.persist(createReview(event2));
+		}
+		for (int i = 0; i < 9; i++) {
+			em.persist(createReview(event3));
+		}
+		for (int i = 0; i < 3; i++) {
+			em.persist(createReview(event4));
+		}
+		for (int i = 0; i < 7; i++) {
+			em.persist(createReview(event5));
+		}
+		em.persist(createReview(event6));
+
+		em.flush();
+		em.clear();
+
+		Pageable pageable = PageRequest.of(1, 2, Sort.Direction.DESC, "likeCount");
+		//when
+		Page<EventsMapRes> events = eventService.getEventsForMap(now, pageable);
+
+		//then
+		assertThat(events).hasSize(2)
+			.extracting("storeName", "likeCount", "reviewCount")
+			.containsExactly(
+				Tuple.tuple("event5", 6L, 7L),
+				Tuple.tuple("event3", 4L, 9L));
+	}
+
 	@DisplayName("이벤트를 수정한다")
 	@Test
 	void updateEvent() throws Exception {
@@ -603,6 +689,12 @@ class EventServiceTest {
 			.toDate(toDate)
 			.hashtag(hashtag)
 			.eventImages(List.of())
+			.build();
+	}
+
+	Review createReview(Event event) {
+		return Review.builder()
+			.event(event)
 			.build();
 	}
 


### PR DESCRIPTION

## Description

> 지도 표기용 Event 목록 조회 기능 구현

## Changes

- EventArtist Artist 외래키 제약조건 제거
- EventController getEventsForMap()
  - EventPageReq
  - EventsMapRes
- EventService getEventsForMap()
- EventRepository findForMap()
  - EventLikeReviewCountDto

## ETC
