### PR TITLE
Feat: #436 - 날짜 기준 event의 hashtag 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -151,23 +151,8 @@ public class EventController {
 	@Operation(summary = "오늘 진행중인 이벤트 해시태그 목록 조회")
 	@GetMapping("/hashtags/today")
 	public List<HashtagRes> getTodayHashtags() {
-		return List.of(
-			HashtagRes.builder()
-				.eventId(1L)
-				.hashtag("#뫄뫄 #생일_축하해")
-				.build(),
-			HashtagRes.builder()
-				.eventId(2L)
-				.hashtag("#소녀시대 #10주년")
-				.build(),
-			HashtagRes.builder()
-				.eventId(3L)
-				.hashtag("#뫄뫄_탄신 #벌써10000일")
-				.build(),
-			HashtagRes.builder()
-				.eventId(4L)
-				.hashtag("#드라마 #대박나자")
-				.build()
-		);
+		LocalDate now = LocalDate.now();
+
+		return eventService.getHashtagResListByDate(now);
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/HashtagRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/HashtagRes.java
@@ -1,5 +1,7 @@
 package com.teamddd.duckmap.dto.event.event;
 
+import com.teamddd.duckmap.entity.Event;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,4 +10,11 @@ import lombok.Getter;
 public class HashtagRes {
 	private Long eventId;
 	private String hashtag;
+
+	public static HashtagRes of(Event event) {
+		return HashtagRes.builder()
+			.eventId(event.getId())
+			.hashtag(event.getHashtag())
+			.build();
+	}
 }

--- a/src/main/java/com/teamddd/duckmap/repository/EventRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/EventRepository.java
@@ -11,6 +11,7 @@ import com.teamddd.duckmap.entity.Event;
 
 public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryCustom {
 
-	@Query("select e.hashtag from Event e where e.fromDate <= :date and e.toDate >= :date")
-	List<String> findHashtagsByFromDateAndToDate(@Param("date") LocalDate date);
+	@Query("select DISTINCT e from Event e join EventArtist ea on e = ea.event join ea.artist a "
+		+ "where e.fromDate <= :date and e.toDate >= :date")
+	List<Event> findByArtistAndDate(@Param("date") LocalDate date);
 }

--- a/src/main/java/com/teamddd/duckmap/service/EventService.java
+++ b/src/main/java/com/teamddd/duckmap/service/EventService.java
@@ -22,6 +22,7 @@ import com.teamddd.duckmap.dto.event.event.EventRes;
 import com.teamddd.duckmap.dto.event.event.EventSearchServiceReq;
 import com.teamddd.duckmap.dto.event.event.EventsMapRes;
 import com.teamddd.duckmap.dto.event.event.EventsRes;
+import com.teamddd.duckmap.dto.event.event.HashtagRes;
 import com.teamddd.duckmap.dto.event.event.MyEventsServiceReq;
 import com.teamddd.duckmap.dto.event.event.MyLikeEventsServiceReq;
 import com.teamddd.duckmap.dto.event.event.UpdateEventServiceReq;
@@ -191,6 +192,12 @@ public class EventService {
 		Page<EventLikeReviewCountDto> events = eventRepository.findForMap(date, pageable);
 
 		return events.map(EventsMapRes::of);
+	}
+
+	public List<HashtagRes> getHashtagResListByDate(LocalDate date) {
+		return eventRepository.findByArtistAndDate(date).stream()
+			.map(HashtagRes::of)
+			.collect(Collectors.toList());
 	}
 
 	@Transactional

--- a/src/test/java/com/teamddd/duckmap/repository/EventRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/EventRepositoryTest.java
@@ -77,9 +77,9 @@ class EventRepositoryTest {
 		assertThat(myEvents.getTotalPages()).isEqualTo(1);
 	}
 
-	@DisplayName("날짜 기준 진행중인 event hashtag 목록 조회")
+	@DisplayName("날짜 기준 진행중이고 Artist가 존재하는 Event hashtag 목록 조회")
 	@Test
-	void findHashtagsByFromDateAndToDate() throws Exception {
+	void findByArtistAndDate() throws Exception {
 		//given
 		LocalDate date = LocalDate.now();
 
@@ -89,7 +89,7 @@ class EventRepositoryTest {
 		Event event1 = createEvent(member, "event1", date.minusDays(10), date.minusDays(6), "#hashtag1");
 		Event event2 = createEvent(member, "event2", date.minusDays(1), date, "#hashtag2");
 		Event event3 = createEvent(member, "event3", date, date.plusDays(1), "#hashtag3");
-		Event event4 = createEvent(member, "event4", date.plusDays(2), date.plusDays(4), "#hashtag4");
+		Event event4 = createEvent(member, "event4", date, date.plusDays(4), "#hashtag4");
 		em.persist(event1);
 		em.persist(event2);
 		em.persist(event3);
@@ -103,28 +103,23 @@ class EventRepositoryTest {
 		EventArtist eventArtist1 = createEventArtist(event1, artist1);
 		EventArtist eventArtist2 = createEventArtist(event1, artist2);
 		EventArtist eventArtist3 = createEventArtist(event2, artist1);
-		EventArtist eventArtist4 = createEventArtist(event3, artist2);
-		EventArtist eventArtist5 = createEventArtist(event4, artist1);
+		EventArtist eventArtist4 = createEventArtist(event2, artist2);
+		EventArtist eventArtist5 = createEventArtist(event3, artist2);
+		EventArtist eventArtist6 = createEventArtist(event4, Artist.builder().id(100L).build());
 		em.persist(eventArtist1);
 		em.persist(eventArtist2);
 		em.persist(eventArtist3);
 		em.persist(eventArtist4);
 		em.persist(eventArtist5);
-
-		EventLike eventLike1 = createEventLike(member, event1);
-		EventLike eventLike2 = createEventLike(member, event2);
-		EventBookmark eventBookmark2 = createEventBookmark(member, event2);
-		EventBookmark eventBookmark3 = createEventBookmark(member, event3);
-		em.persist(eventLike1);
-		em.persist(eventLike2);
-		em.persist(eventBookmark2);
-		em.persist(eventBookmark3);
+		em.persist(eventArtist6);
 
 		//when
-		List<String> hashtags = eventRepository.findHashtagsByFromDateAndToDate(date);
+		List<Event> hashtags = eventRepository.findByArtistAndDate(date);
 
 		//then
-		assertThat(hashtags).hasSize(2).containsExactly("#hashtag2", "#hashtag3");
+		assertThat(hashtags).hasSize(2)
+			.extracting("hashtag")
+			.containsExactly("#hashtag2", "#hashtag3");
 	}
 
 	@DisplayName("member fk가 좋아요한 event 목록 조회")

--- a/src/test/java/com/teamddd/duckmap/service/EventServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/EventServiceTest.java
@@ -28,6 +28,7 @@ import com.teamddd.duckmap.dto.event.event.EventRes;
 import com.teamddd.duckmap.dto.event.event.EventSearchServiceReq;
 import com.teamddd.duckmap.dto.event.event.EventsMapRes;
 import com.teamddd.duckmap.dto.event.event.EventsRes;
+import com.teamddd.duckmap.dto.event.event.HashtagRes;
 import com.teamddd.duckmap.dto.event.event.MyEventsServiceReq;
 import com.teamddd.duckmap.dto.event.event.MyLikeEventsServiceReq;
 import com.teamddd.duckmap.dto.event.event.UpdateEventServiceReq;
@@ -514,6 +515,50 @@ class EventServiceTest {
 			.containsExactly(
 				Tuple.tuple("event5", 6L, 7L),
 				Tuple.tuple("event3", 4L, 9L));
+	}
+
+	@DisplayName("날짜 기준 진행중인 Event의 HashtagsRes 목록 조회")
+	@Test
+	void getHashtagResListByDate() throws Exception {
+		//given
+		LocalDate date = LocalDate.now();
+
+		Event event1 = createEvent(null, "event1", date.minusDays(10), date.minusDays(6), "#hashtag1");
+		Event event2 = createEvent(null, "event2", date.minusDays(1), date, "#hashtag2");
+		Event event3 = createEvent(null, "event3", date, date.plusDays(1), "#hashtag3");
+		Event event4 = createEvent(null, "event4", date, date.plusDays(4), "#hashtag4");
+		em.persist(event1);
+		em.persist(event2);
+		em.persist(event3);
+		em.persist(event4);
+
+		Artist artist1 = Artist.builder().build();
+		Artist artist2 = Artist.builder().build();
+		em.persist(artist1);
+		em.persist(artist2);
+
+		EventArtist eventArtist1 = createEventArtist(event1, artist1);
+		EventArtist eventArtist2 = createEventArtist(event1, artist2);
+		EventArtist eventArtist3 = createEventArtist(event2, artist1);
+		EventArtist eventArtist4 = createEventArtist(event2, artist2);
+		EventArtist eventArtist5 = createEventArtist(event3, artist2);
+		EventArtist eventArtist6 = createEventArtist(event4, Artist.builder().id(100L).build());
+		em.persist(eventArtist1);
+		em.persist(eventArtist2);
+		em.persist(eventArtist3);
+		em.persist(eventArtist4);
+		em.persist(eventArtist5);
+		em.persist(eventArtist6);
+
+		//when
+		List<HashtagRes> hashtagResList = eventService.getHashtagResListByDate(date);
+
+		//then
+		assertThat(hashtagResList).hasSize(2)
+			.extracting("eventId", "hashtag")
+			.containsExactly(
+				Tuple.tuple(event2.getId(), event2.getHashtag()),
+				Tuple.tuple(event3.getId(), event3.getHashtag()));
 	}
 
 	@DisplayName("이벤트를 수정한다")


### PR DESCRIPTION
## Description

> 날짜 기준 event의 hashtag 목록 조회 기능 구현

## Changes

- EventController getTodayHashtags()
  - HashtagRes of()
- EventService getHashtagResListByDate()
- EventRepository findByArtistAndDate()

## ETC
