### PR TITLE
Feat: #439 - event 목록 조회 시 LastSearchArtist 값 변경 기능 구현

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -1,9 +1,9 @@
-name: Close issues
+name: Close issues related to a merged pull request based on master branch.
+
 on:
   pull_request:
     types: [ closed ]
     branches:
-      - dev
       - feature/**
 
 jobs:

--- a/src/main/java/com/teamddd/duckmap/controller/EventController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/EventController.java
@@ -92,15 +92,12 @@ public class EventController {
 	@Operation(summary = "이벤트 목록 조회")
 	@GetMapping
 	public Page<EventsRes> getEvents(PageReq pageReq, @ModelAttribute EventSearchParam eventSearchParam) {
-
-		Long memberId = MemberUtils.getMember()
-			.map(Member::getId)
-			.orElse(null);
-
 		LocalDate today = LocalDate.now();
+
 		Pageable pageable = PageRequest.of(pageReq.getPageNumber(), pageReq.getPageSize());
+
 		EventSearchServiceReq request = EventSearchServiceReq.builder()
-			.memberId(memberId)
+			.member(MemberUtils.getMember())
 			.date(today)
 			.artistId(eventSearchParam.getArtistId())
 			.onlyInProgress(BooleanUtils.isTrue(eventSearchParam.getOnlyInProgress()))

--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventSearchServiceReq.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventSearchServiceReq.java
@@ -1,8 +1,11 @@
 package com.teamddd.duckmap.dto.event.event;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
+
+import com.teamddd.duckmap.entity.Member;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +13,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class EventSearchServiceReq {
-	private Long memberId;
+	private Optional<Member> member;
 	private LocalDate date;
 	private Long artistId;
 	private boolean onlyInProgress;

--- a/src/main/java/com/teamddd/duckmap/entity/LastSearchArtist.java
+++ b/src/main/java/com/teamddd/duckmap/entity/LastSearchArtist.java
@@ -25,11 +25,14 @@ public class LastSearchArtist extends BaseTimeEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
+	@JoinColumn(name = "member_id", unique = true)
 	private Member member;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "artist_id")
 	private Artist artist;
 
+	public void changeSearchArtist(Artist artist) {
+		this.artist = artist;
+	}
 }

--- a/src/main/java/com/teamddd/duckmap/repository/LastSearchArtistRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/LastSearchArtistRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.teamddd.duckmap.entity.LastSearchArtist;
+import com.teamddd.duckmap.entity.Member;
 
 public interface LastSearchArtistRepository extends JpaRepository<LastSearchArtist, Long> {
 	Optional<LastSearchArtist> findByMemberId(Long memberId);
@@ -15,4 +16,6 @@ public interface LastSearchArtistRepository extends JpaRepository<LastSearchArti
 	@Modifying(clearAutomatically = true)
 	@Query("delete from LastSearchArtist lsa where lsa.artist.id = :artistId")
 	int deleteByArtistId(@Param("artistId") Long artistId);
+
+	Optional<LastSearchArtist> findByMember(Member member);
 }

--- a/src/main/java/com/teamddd/duckmap/service/EventService.java
+++ b/src/main/java/com/teamddd/duckmap/service/EventService.java
@@ -55,6 +55,7 @@ public class EventService {
 	private final EventRepository eventRepository;
 	private final ArtistService artistService;
 	private final EventCategoryService eventCategoryService;
+	private final LastSearchArtistService lastSearchArtistService;
 	private final ReviewRepository reviewRepository;
 	private final EventLikeRepository eventLikeRepository;
 	private final BookmarkRepository eventBookmarkRepository;
@@ -162,12 +163,16 @@ public class EventService {
 
 	public Page<EventsRes> getEventsResList(EventSearchServiceReq request) {
 		if (request.getArtistId() != null) {
-			artistService.getArtist(request.getArtistId());
+			Artist searchArtist = artistService.getArtist(request.getArtistId());
+
+			request.getMember()
+				.ifPresent(member -> lastSearchArtistService.saveLastSearchArtist(member, searchArtist));
 		}
 
 		LocalDate searchDate = request.isOnlyInProgress() ? request.getDate() : null;
 		Page<EventLikeBookmarkDto> eventLikeBookmarkDtos = eventRepository.findByArtistAndDate(request.getArtistId(),
-			searchDate, request.getMemberId(),
+			searchDate,
+			request.getMember().map(Member::getId).orElse(null),
 			request.getPageable());
 
 		return eventLikeBookmarkDtos

--- a/src/main/java/com/teamddd/duckmap/service/LastSearchArtistService.java
+++ b/src/main/java/com/teamddd/duckmap/service/LastSearchArtistService.java
@@ -1,0 +1,37 @@
+package com.teamddd.duckmap.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.LastSearchArtist;
+import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.repository.LastSearchArtistRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LastSearchArtistService {
+	private final LastSearchArtistRepository lastSearchArtistRepository;
+
+	@Transactional
+	public void saveLastSearchArtist(Member member, Artist artist) {
+		Optional<LastSearchArtist> lastSearch = lastSearchArtistRepository.findByMember(member);
+
+		lastSearch.ifPresentOrElse(
+			lastSearchArtist -> lastSearchArtist.changeSearchArtist(artist),
+			() -> lastSearchArtistRepository.save(
+				LastSearchArtist.builder()
+					.member(member)
+					.artist(artist)
+					.build()
+			)
+		);
+	}
+}

--- a/src/test/java/com/teamddd/duckmap/repository/LastSearchArtistRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/LastSearchArtistRepositoryTest.java
@@ -3,6 +3,7 @@ package com.teamddd.duckmap.repository;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.persistence.EntityManager;
 
@@ -50,6 +51,34 @@ class LastSearchArtistRepositoryTest {
 
 		List<LastSearchArtist> findLastSearchArtists = lastSearchArtistRepository.findAll();
 		assertThat(findLastSearchArtists).hasSize(0);
+	}
+
+	@DisplayName("Member로 LastSearchArtist 조회")
+	@Test
+	void findByMember() throws Exception {
+		//given
+		Member member1 = createMember("member1");
+		Member member2 = createMember("member2");
+		em.persist(member1);
+		em.persist(member2);
+
+		Artist artist1 = createArtist("artist1");
+		Artist artist2 = createArtist("artist2");
+		em.persist(artist1);
+		em.persist(artist2);
+
+		LastSearchArtist lastSearchArtist1 = createLastSearchArtist(member1, artist1);
+		LastSearchArtist lastSearchArtist2 = createLastSearchArtist(member2, artist2);
+		em.persist(lastSearchArtist1);
+		em.persist(lastSearchArtist2);
+
+		//when
+		Optional<LastSearchArtist> findLastSearch = lastSearchArtistRepository.findByMember(member1);
+
+		//then
+		assertThat(findLastSearch).isNotEmpty();
+		assertThat(findLastSearch.get()).extracting("member.email", "artist.name")
+			.containsExactly("member1", "artist1");
 	}
 
 	Member createMember(String email) {

--- a/src/test/java/com/teamddd/duckmap/service/LastSearchArtistServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/LastSearchArtistServiceTest.java
@@ -1,0 +1,101 @@
+package com.teamddd.duckmap.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.teamddd.duckmap.entity.Artist;
+import com.teamddd.duckmap.entity.LastSearchArtist;
+import com.teamddd.duckmap.entity.Member;
+import com.teamddd.duckmap.repository.LastSearchArtistRepository;
+
+@Transactional
+@SpringBootTest
+class LastSearchArtistServiceTest {
+	@Autowired
+	EntityManager em;
+	@Autowired
+	LastSearchArtistService lastSearchArtistService;
+	@Autowired
+	LastSearchArtistRepository lastSearchArtistRepository;
+
+	Member createMember(String email) {
+		return Member.builder()
+			.email(email)
+			.build();
+	}
+
+	Artist createArtist(String name) {
+		return Artist.builder()
+			.name(name)
+			.build();
+	}
+
+	LastSearchArtist createLastSearchArtist(Member member, Artist artist) {
+		return LastSearchArtist.builder()
+			.member(member)
+			.artist(artist)
+			.build();
+	}
+
+	@DisplayName("마지막 검색 아티스트를 저장한다")
+	@Nested
+	class SaveLastSearchArtist {
+		@DisplayName("기존에 검색한 기록이 없는 경우")
+		@Test
+		void saveLastSearchArtist1() throws Exception {
+			//given
+			Member member1 = createMember("member1");
+			em.persist(member1);
+
+			Artist artist1 = createArtist("artist1");
+			em.persist(artist1);
+
+			//when
+			lastSearchArtistService.saveLastSearchArtist(member1, artist1);
+
+			//then
+			Optional<LastSearchArtist> findLastSearch = lastSearchArtistRepository.findByMember(member1);
+
+			assertThat(findLastSearch).isNotEmpty();
+			assertThat(findLastSearch.get().getId()).isNotNull();
+			assertThat(findLastSearch.get()).extracting("member.email", "artist.name")
+				.containsExactly("member1", "artist1");
+		}
+
+		@DisplayName("기존에 검색한 기록이 있는 경우")
+		@Test
+		void saveLastSearchArtist2() throws Exception {
+			//given
+			Member member1 = createMember("member1");
+			em.persist(member1);
+
+			Artist beforeArtist = createArtist("before");
+			Artist afterArtist = createArtist("after");
+			em.persist(beforeArtist);
+			em.persist(afterArtist);
+
+			LastSearchArtist lastSearchArtist1 = createLastSearchArtist(member1, beforeArtist);
+			em.persist(lastSearchArtist1);
+
+			//when
+			lastSearchArtistService.saveLastSearchArtist(member1, afterArtist);
+
+			//then
+			Optional<LastSearchArtist> findLastSearch = lastSearchArtistRepository.findByMember(member1);
+
+			assertThat(findLastSearch).isNotEmpty();
+			assertThat(findLastSearch.get()).extracting("member.email", "artist.name")
+				.containsExactly("member1", "after");
+		}
+	}
+}


### PR DESCRIPTION
## Description

> event 목록 조회 시 LastSearchArtist 값 변경 기능 구현

## Changes

- LastSearchArtist
  - Member unique 조건 추가
  - changeSearchArtist() 구현
- EventController getEvents()
  - EventSearchServiceReq Long memberId -> Optional<Member> member
- EventService getEventsResList()
  - EventSearchServiceReq에 artistId와 member가 있으면 LastSearchArtist 저장 기능 호출
- LastSearchArtistService saveLastSearchArtist()
- LastSearchArtistRepository findByMember()

## ETC
변경사항이 너무 많네요.. 커밋을 나눴어야 했는데 죄송합니다
