### PR TITLE
Feat: #444 - 아티스트 목록 조회시 아티스트 타입 id로 sort 적용

### DIFF
--- a/src/main/java/com/teamddd/duckmap/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/com/teamddd/duckmap/repository/ArtistRepositoryImpl.java
@@ -33,6 +33,7 @@ public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
 			.where(eqArtistTypeId(artistTypeId),
 				containsArtistOrGroupName(name)
 			)
+			.orderBy(artist.artistType.id.asc(), artist.name.asc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();

--- a/src/test/java/com/teamddd/duckmap/repository/ArtistRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/ArtistRepositoryTest.java
@@ -176,7 +176,7 @@ class ArtistRepositoryTest {
 			//then
 			assertThat(findArtists).hasSize(3)
 				.extracting("name")
-				.containsExactlyInAnyOrder("group1", "group2", "artist2");
+				.containsExactly("group1", "group2", "artist2");
 
 			assertThat(findArtists.getTotalElements()).isEqualTo(7);
 			assertThat(findArtists.getTotalPages()).isEqualTo(3);
@@ -216,7 +216,7 @@ class ArtistRepositoryTest {
 			//then
 			assertThat(findArtists).hasSize(3)
 				.extracting("name", "group.name")
-				.containsExactlyInAnyOrder(Tuple.tuple("group2", null), Tuple.tuple("artist2", "group1"),
+				.containsExactly(Tuple.tuple("group2", null), Tuple.tuple("artist2", "group1"),
 					Tuple.tuple("artist4", "group2"));
 
 			assertThat(findArtists.getTotalElements()).isEqualTo(3);
@@ -257,7 +257,7 @@ class ArtistRepositoryTest {
 			//then
 			assertThat(findArtists).hasSize(2)
 				.extracting("name", "artistType.id")
-				.containsExactlyInAnyOrder(
+				.containsExactly(
 					Tuple.tuple("artist2", type2.getId()),
 					Tuple.tuple("artist3", type2.getId()));
 
@@ -299,7 +299,7 @@ class ArtistRepositoryTest {
 			//then
 			assertThat(findArtists).hasSize(2)
 				.extracting("name", "group.name", "artistType.id")
-				.containsExactlyInAnyOrder(
+				.containsExactly(
 					Tuple.tuple("artist2", "group1", type2.getId()),
 					Tuple.tuple("artist3", "group1", type2.getId()));
 


### PR DESCRIPTION
## Description

> 아티스트 목록 조회시 아티스트 타입 id, 아티스트 이름 오름차순으로 sort 적용

## Changes

- ArtistRepository findByTypeAndName()

## ETC
