### PR TITLE
ArtistService getArtistResListByIds() 구현

### DIFF
--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventsRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventsRes.java
@@ -1,16 +1,9 @@
 package com.teamddd.duckmap.dto.event.event;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import com.teamddd.duckmap.common.ApiUrl;
 import com.teamddd.duckmap.dto.artist.ArtistRes;
 import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
-import com.teamddd.duckmap.entity.Event;
-import com.teamddd.duckmap.entity.EventArtist;
-import com.teamddd.duckmap.entity.EventImage;
-import com.teamddd.duckmap.entity.EventInfoCategory;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -27,39 +20,4 @@ public class EventsRes {
 	private String image;
 	private Long likeId;
 	private Long bookmarkId;
-
-	public static EventsRes of(EventLikeBookmarkDto eventLikeBookmarkDto, LocalDate date) {
-		Event event = eventLikeBookmarkDto.getEvent();
-		Long likeId = eventLikeBookmarkDto.getLikeId();
-		Long bookmarkId = eventLikeBookmarkDto.getBookmarkId();
-
-		return EventsRes.builder()
-			.id(event.getId())
-			.storeName(event.getStoreName())
-			.inProgress(event.isInProgress(date))
-			.address(event.getAddress())
-			.artists(
-				event.getEventArtists().stream()
-					.map(EventArtist::getArtist)
-					.map(ArtistRes::of)
-					.collect(Collectors.toList())
-			)
-			.categories(
-				event.getEventInfoCategories().stream()
-					.map(EventInfoCategory::getEventCategory)
-					.map(EventCategoryRes::of)
-					.collect(Collectors.toList())
-			)
-			.image(
-				event.getEventImages().stream()
-					.filter(EventImage::isThumbnail)
-					.map(EventImage::getImage)
-					.map(image -> ApiUrl.IMAGE + image)
-					.findFirst()
-					.orElse(null)
-			)
-			.likeId(likeId)
-			.bookmarkId(bookmarkId)
-			.build();
-	}
 }

--- a/src/main/java/com/teamddd/duckmap/repository/ArtistRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/ArtistRepository.java
@@ -2,6 +2,7 @@ package com.teamddd.duckmap.repository;
 
 import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +16,9 @@ public interface ArtistRepository extends JpaRepository<Artist, Long>, ArtistRep
 	List<Artist> findByGroup(Artist group);
 
 	List<Artist> findByIdIn(List<Long> id);
+
+	@EntityGraph(attributePaths = {"group", "artistType"})
+	List<Artist> findWithTypeAndGroupByIdIn(List<Long> id);
 
 	Long countByArtistType(ArtistType artistType);
 

--- a/src/main/java/com/teamddd/duckmap/service/ArtistService.java
+++ b/src/main/java/com/teamddd/duckmap/service/ArtistService.java
@@ -73,6 +73,12 @@ public class ArtistService {
 		throw new NonExistentArtistException();
 	}
 
+	public List<ArtistRes> getArtistResListByIds(List<Long> ids) {
+		return artistRepository.findWithTypeAndGroupByIdIn(ids).stream()
+			.map(ArtistRes::of)
+			.collect(Collectors.toList());
+	}
+
 	public Page<ArtistRes> getArtistResPageByTypeAndName(ArtistSearchParam artistSearchParam, Pageable pageable) {
 		Page<Artist> artistPage = artistRepository.findByTypeAndName(
 			artistSearchParam.getArtistTypeId(),

--- a/src/test/java/com/teamddd/duckmap/repository/ArtistRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/ArtistRepositoryTest.java
@@ -86,6 +86,38 @@ class ArtistRepositoryTest {
 			.containsExactlyInAnyOrder("artist2", "artist4");
 	}
 
+	@DisplayName("pk 목록으로 artist 목록 조회 시 Group, Type fetch join")
+	@Test
+	void findWithTypeAndGroupByIdIn() throws Exception {
+		//given
+		ArtistType type1 = createArtistType("type1");
+		ArtistType type2 = createArtistType("type2");
+		em.persist(type1);
+		em.persist(type2);
+
+		Artist artist1 = createArtist("artist1", type1, null);
+		Artist artist2 = createArtist("artist2", type2, artist1);
+		Artist artist3 = createArtist("artist3", type2, null);
+		em.persist(artist1);
+		em.persist(artist2);
+		em.persist(artist3);
+
+		em.flush();
+		em.clear();
+
+		//when
+		List<Artist> artists = artistRepository.findWithTypeAndGroupByIdIn(
+			List.of(artist1.getId(), artist2.getId(), artist3.getId()));
+
+		//then
+		assertThat(artists).hasSize(3)
+			.extracting("name", "artistType.type", "group.name")
+			.containsExactly(
+				Tuple.tuple("artist1", "type1", null),
+				Tuple.tuple("artist2", "type2", "artist1"),
+				Tuple.tuple("artist3", "type2", null));
+	}
+
 	@DisplayName("아티스트 구분으로 아티스트 수 조회")
 	@Test
 	void countByArtistType() throws Exception {

--- a/src/test/java/com/teamddd/duckmap/service/ArtistServiceTest.java
+++ b/src/test/java/com/teamddd/duckmap/service/ArtistServiceTest.java
@@ -80,13 +80,13 @@ class ArtistServiceTest {
 		ArtistType type1 = createArtistType("type1");
 		ArtistType type2 = createArtistType("type2");
 
-		Artist artist1 = createArtist(type1, "group1", null);
-		Artist artist2 = createArtist(type1, "group2", null);
-		Artist artist3 = createArtist(type2, "artist3", artist1);
-		Artist artist4 = createArtist(type2, "artist4", artist1);
-		Artist artist5 = createArtist(type2, "artist5", artist2);
-		Artist artist6 = createArtist(type2, "artist6", artist2);
-		Artist artist7 = createArtist(type2, "artist7", artist2);
+		Artist artist1 = createArtist("group1", type1, null);
+		Artist artist2 = createArtist("group2", type1, null);
+		Artist artist3 = createArtist("artist3", type2, artist1);
+		Artist artist4 = createArtist("artist4", type2, artist1);
+		Artist artist5 = createArtist("artist5", type2, artist2);
+		Artist artist6 = createArtist("artist6", type2, artist2);
+		Artist artist7 = createArtist("artist7", type2, artist2);
 		List<Artist> artists = List.of(artist1, artist2, artist3, artist4, artist5, artist6, artist7);
 
 		ArtistSearchParam param = ArtistSearchParam.builder().build();
@@ -115,10 +115,10 @@ class ArtistServiceTest {
 		ArtistType type1 = createArtistType("type1");
 		ArtistType type2 = createArtistType("type2");
 
-		Artist artist1 = createArtist(type1, "group1", null);
-		Artist artist2 = createArtist(type2, "artist2", artist1);
-		Artist artist3 = createArtist(type2, "artist3", artist1);
-		Artist artist4 = createArtist(type2, "artist4", artist1);
+		Artist artist1 = createArtist("group1", type1, null);
+		Artist artist2 = createArtist("artist2", type2, artist1);
+		Artist artist3 = createArtist("artist3", type2, artist1);
+		Artist artist4 = createArtist("artist4", type2, artist1);
 		List<Artist> artists = List.of(artist2, artist3, artist4);
 
 		Long groupId = 1L;
@@ -141,7 +141,7 @@ class ArtistServiceTest {
 	@Test
 	void deleteArtist() throws Exception {
 		//given
-		Artist artist1 = createArtist(null, "artist1", null);
+		Artist artist1 = createArtist("artist1", null, null);
 		em.persist(artist1);
 
 		when(artistRepository.bulkGroupToNull(anyLong())).thenReturn(0);
@@ -158,11 +158,43 @@ class ArtistServiceTest {
 		assertThat(findArtist).isEmpty();
 	}
 
+	@DisplayName("pk목록으로 ArtistRes 목록을 조회한다")
+	@Test
+	void getArtistResListByIds() throws Exception {
+		//given
+		ArtistType type1 = createArtistType("type1");
+		ArtistType type2 = createArtistType("type2");
+		em.persist(type1);
+		em.persist(type2);
+
+		Artist artist1 = createArtist("artist1", type1, null);
+		Artist artist2 = createArtist("artist2", type2, artist1);
+		Artist artist3 = createArtist("artist3", type2, null);
+		em.persist(artist1);
+		em.persist(artist2);
+		em.persist(artist3);
+
+		em.flush();
+		em.clear();
+
+		//when
+		List<ArtistRes> artistResList = artistService.getArtistResListByIds(
+			List.of(artist1.getId(), artist2.getId(), artist3.getId()));
+
+		//then
+		assertThat(artistResList).hasSize(3)
+			.extracting("name", "artistType.type", "groupName")
+			.containsExactly(
+				Tuple.tuple("artist1", "type1", null),
+				Tuple.tuple("artist2", "type2", "artist1"),
+				Tuple.tuple("artist3", "type2", null));
+	}
+
 	ArtistType createArtistType(String type) {
 		return ArtistType.builder().type(type).build();
 	}
 
-	Artist createArtist(ArtistType type, String name, Artist group) {
+	Artist createArtist(String name, ArtistType type, Artist group) {
 		return Artist.builder().artistType(type).name(name).group(group).image("image").build();
 	}
 
@@ -173,9 +205,9 @@ class ArtistServiceTest {
 		@Test
 		void getArtistsByIds1() throws Exception {
 			//given
-			Artist artist1 = createArtist(null, "artist1", null);
-			Artist artist2 = createArtist(null, "artist2", null);
-			Artist artist3 = createArtist(null, "artist3", null);
+			Artist artist1 = createArtist("artist1", null, null);
+			Artist artist2 = createArtist("artist2", null, null);
+			Artist artist3 = createArtist("artist3", null, null);
 			artistRepository.saveAll(List.of(artist1, artist2, artist3));
 
 			List<Long> inIds = List.of(artist2.getId(), artist3.getId());
@@ -191,9 +223,9 @@ class ArtistServiceTest {
 		@Test
 		void getArtistsByIds2() throws Exception {
 			//given
-			Artist artist1 = createArtist(null, "artist1", null);
-			Artist artist2 = createArtist(null, "artist2", null);
-			Artist artist3 = createArtist(null, "artist3", null);
+			Artist artist1 = createArtist("artist1", null, null);
+			Artist artist2 = createArtist("artist2", null, null);
+			Artist artist3 = createArtist("artist3", null, null);
 			artistRepository.saveAll(List.of(artist1, artist2, artist3));
 
 			List<Long> inIds = List.of(artist2.getId(), 100L);
@@ -214,8 +246,8 @@ class ArtistServiceTest {
 			ArtistType type = createArtistType("type");
 			em.persist(type);
 
-			Artist group = createArtist(null, "group", null);
-			Artist artist = createArtist(null, "artist", group);
+			Artist group = createArtist("group", null, null);
+			Artist artist = createArtist("artist", null, group);
 			em.persist(group);
 			em.persist(artist);
 
@@ -251,8 +283,8 @@ class ArtistServiceTest {
 			ArtistType type = createArtistType("type");
 			em.persist(type);
 
-			Artist group = createArtist(null, "group", null);
-			Artist artist = createArtist(null, "artist", null);
+			Artist group = createArtist("group", null, null);
+			Artist artist = createArtist("artist", null, null);
 			em.persist(group);
 			em.persist(artist);
 


### PR DESCRIPTION
## Description

> ArtistService getArtistResListByIds() 구현으로 EventsRes 목록 반환 시 Lazy 조회 방지

## Changes

- ArtistRepository findWithTypeAndGroupByIdIn()
- ArtistService getArtistResListByIds()
- EventService convertEventLikeBookmarkToEventsRes()
- EventsRes of() 제거

## ETC
