### PR TITLE
Fix: #465 - Artist가 없는 EventsRes 변환 시 에러 발생

### DIFF
--- a/src/main/java/com/teamddd/duckmap/dto/event/event/EventsRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/event/event/EventsRes.java
@@ -2,6 +2,7 @@ package com.teamddd.duckmap.dto.event.event;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.teamddd.duckmap.common.ApiUrl;
@@ -41,6 +42,7 @@ public class EventsRes {
 			.artists(
 				event.getEventArtists().stream()
 					.map(EventArtist::getArtist)
+					.filter(Objects::nonNull)
 					.map(ArtistRes::of)
 					.collect(Collectors.toList())
 			)


### PR DESCRIPTION
## Description

> Artist가 없는 EventsRes 변환 시 에러 발생

## Changes

- EventsRes of()

## ETC
버그라서 메인에 pr 했습니다
