### PR TITLE
Feat: #470 - Event 제거 시 Review fk null로 변경

### DIFF
--- a/src/main/java/com/teamddd/duckmap/repository/ReviewRepository.java
+++ b/src/main/java/com/teamddd/duckmap/repository/ReviewRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +22,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 
 	@Query("select ROUND(avg(r.score), 1) from Review r where r.event.id = :eventId")
 	Optional<Double> avgScoreByEvent(@Param("eventId") Long eventId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("update Review r set r.event = null where r.event.id = :eventId")
+	int updateEventToNull(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/teamddd/duckmap/service/EventService.java
+++ b/src/main/java/com/teamddd/duckmap/service/EventService.java
@@ -286,6 +286,8 @@ public class EventService {
 		eventLikeRepository.deleteByEventId(id);
 		eventBookmarkRepository.deleteByEventId(id);
 
+		reviewRepository.updateEventToNull(id);
+
 		eventRepository.deleteById(id);
 
 		for (String filename : filenames) {

--- a/src/test/java/com/teamddd/duckmap/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/teamddd/duckmap/repository/ReviewRepositoryTest.java
@@ -3,6 +3,7 @@ package com.teamddd.duckmap.repository;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import javax.persistence.EntityManager;
@@ -290,6 +291,37 @@ class ReviewRepositoryTest {
 			.event(event)
 			.artist(artist)
 			.build();
+	}
+
+	@DisplayName("Event fk를 null로 update")
+	@Test
+	void updateEventToNull() throws Exception {
+		//given
+		Event event1 = createEvent("event1");
+		Event event2 = createEvent("event2");
+		em.persist(event1);
+		em.persist(event2);
+
+		Review review1 = createReview(null, event1, "review1", 0);
+		Review review2 = createReview(null, event2, "review2", 0);
+		Review review3 = createReview(null, event1, "review3", 0);
+		em.persist(review1);
+		em.persist(review2);
+		em.persist(review3);
+
+		//when
+		int count = reviewRepository.updateEventToNull(event1.getId());
+
+		//then
+		assertThat(count).isEqualTo(2);
+
+		List<Review> findReviews = reviewRepository.findAll();
+		assertThat(findReviews).hasSize(3)
+			.extracting("content", "event.storeName")
+			.containsExactlyInAnyOrder(
+				Tuple.tuple("review1", null),
+				Tuple.tuple("review2", "event2"),
+				Tuple.tuple("review3", null));
 	}
 
 	@Nested


### PR DESCRIPTION
## Description

> Event 제거 시 Review fk null로 변경

## Changes

- EventService deleteEvent()
- ReviewRepository updateEventToNull()

## ETC
