### PR TITLE
!HOTFIX: ResponseCookie.secure 설정 삭제

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -46,7 +46,6 @@ public class AuthController {
 		HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
 			.maxAge(COOKIE_EXPIRATION)
 			.httpOnly(true)
-			.secure(true)
 			.build();
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, httpCookie.toString())


### PR DESCRIPTION
## Description

> ResponseCookie.secure 설정 삭제

## Changes


## ETC
- https로 변경 전에는 secure설정을 하지 않는다.
- 추후 https로 변경하면 secure(true)로 변경할 것.