### PR TITLE
ResponseCookie 관련 설정 변경

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -46,7 +46,7 @@ public class AuthController {
 		HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
 			.maxAge(COOKIE_EXPIRATION)
 			.path("/")
-			.httpOnly(false)
+			.httpOnly(true)
 			.sameSite("None")
 			.secure(true)
 			.build();

--- a/src/main/java/com/teamddd/duckmap/controller/AuthController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/AuthController.java
@@ -46,7 +46,9 @@ public class AuthController {
 		HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
 			.maxAge(COOKIE_EXPIRATION)
 			.path("/")
-			.httpOnly(true)
+			.httpOnly(false)
+			.sameSite("None")
+			.secure(true)
 			.build();
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, httpCookie.toString())


### PR DESCRIPTION
## Description

> 로그인시 Set-Cookie로 브라우저에 쿠키가 자동 저장 되도록 수정한다.

## Changes

- httpOnly를 true로 변경
- sameSite를 None, secure를 true로 설정하여 Cross Domain에서 제약없이 저장하도록 함 

## ETC
