### PR TITLE
getEventReviews()에 mapping된 URL이 다른 URL과 동일하지 않도록 수정

### DIFF
--- a/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
@@ -109,7 +109,7 @@ public class ReviewController {
 	}
 
 	@Operation(summary = "이벤트의 리뷰 목록 조회")
-	@GetMapping("/{eventId}")
+	@GetMapping("/event-review-list/{eventId}")
 	public Page<EventReviewsRes> getEventReviews(@PathVariable Long eventId, PageReq pageReq) {
 		Pageable pageable = PageRequest.of(pageReq.getPageNumber(), pageReq.getPageSize());
 		EventReviewServiceReq request = EventReviewServiceReq.builder()

--- a/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
+++ b/src/main/java/com/teamddd/duckmap/controller/ReviewController.java
@@ -109,7 +109,7 @@ public class ReviewController {
 	}
 
 	@Operation(summary = "이벤트의 리뷰 목록 조회")
-	@GetMapping("/event-review-list/{eventId}")
+	@GetMapping("/event/{eventId}")
 	public Page<EventReviewsRes> getEventReviews(@PathVariable Long eventId, PageReq pageReq) {
 		Pageable pageable = PageRequest.of(pageReq.getPageNumber(), pageReq.getPageSize());
 		EventReviewServiceReq request = EventReviewServiceReq.builder()


### PR DESCRIPTION
## Description

> getEventReviews()에 mapping된 URL이 다른 URL과 동일하지 않도록 수정


## Changes

-  Ambiguous handler methods mapped for HTTP path 오류 발생하여 해당 URL을 수정했습니다. 
  - @GetMapping("/{id}")와 @GetMapping("/{eventId}")는 같은 GET 요청, Long 타입이기 때문에 동일한 URL로 받아들여진다고 합니다. 
  - 따라서 이벤트의 리뷰 목록 조회는 구분해주기 위하여 @GetMapping("/event/{eventId}")로 변경했습니다.

## ETC
