### PR TITLE
리뷰 전체 목록 조회 api,리뷰 상세정보 조회 api 수정

### DIFF
--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewRes.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.teamddd.duckmap.common.ApiUrl;
+import com.teamddd.duckmap.entity.Event;
 import com.teamddd.duckmap.entity.Review;
 import com.teamddd.duckmap.entity.ReviewImage;
 
@@ -21,8 +22,12 @@ public class ReviewRes {
 	private int score;
 	private String content;
 	private List<String> photos;
+	private Long eventId;
+	private String eventStoreName;
+	private String hashtag;
 
 	public static ReviewRes of(Review review) {
+		Event event = review.getEvent();
 		List<String> imageResList = review.getReviewImages().stream()
 			.map(ReviewImage::getImage)
 			.map(image -> ApiUrl.IMAGE + image)
@@ -36,6 +41,9 @@ public class ReviewRes {
 			.score(review.getScore())
 			.content(review.getContent())
 			.photos(imageResList)
+			.eventId(event.getId())
+			.eventStoreName(event.getStoreName())
+			.hashtag(event.getHashtag())
 			.build();
 	}
 }

--- a/src/main/java/com/teamddd/duckmap/dto/review/ReviewsRes.java
+++ b/src/main/java/com/teamddd/duckmap/dto/review/ReviewsRes.java
@@ -1,8 +1,16 @@
 package com.teamddd.duckmap.dto.review;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import com.teamddd.duckmap.common.ApiUrl;
+import com.teamddd.duckmap.dto.artist.ArtistRes;
+import com.teamddd.duckmap.dto.event.category.EventCategoryRes;
+import com.teamddd.duckmap.entity.Event;
+import com.teamddd.duckmap.entity.EventArtist;
+import com.teamddd.duckmap.entity.EventInfoCategory;
 import com.teamddd.duckmap.entity.Review;
 import com.teamddd.duckmap.entity.ReviewImage;
 
@@ -14,9 +22,13 @@ import lombok.Getter;
 public class ReviewsRes {
 	private Long id;
 	private boolean inProgress;
+	private int score;
 	private String image;
+	private List<ArtistRes> artists;
+	private List<EventCategoryRes> categories;
 
 	public static ReviewsRes of(Review review, LocalDate date) {
+		Event event = review.getEvent();
 		return ReviewsRes.builder()
 			.id(review.getId())
 			.image(
@@ -26,7 +38,21 @@ public class ReviewsRes {
 					.map(image -> ApiUrl.IMAGE + image)
 					.orElse(null)
 			)
-			.inProgress(review.getEvent().isInProgress(date))
+			.score(review.getScore())
+			.inProgress(event.isInProgress(date))
+			.artists(
+				event.getEventArtists().stream()
+					.map(EventArtist::getArtist)
+					.filter(Objects::nonNull)
+					.map(ArtistRes::of)
+					.collect(Collectors.toList())
+			)
+			.categories(
+				event.getEventInfoCategories().stream()
+					.map(EventInfoCategory::getEventCategory)
+					.map(EventCategoryRes::of)
+					.collect(Collectors.toList())
+			)
 			.build();
 	}
 


### PR DESCRIPTION
## Description

> https://github.com/duck-map-project/duck-map-be/issues/517

## Changes

- 리뷰 전체 목록을 조회할 때 별점, 아티스트list, 카테고리list를 반환
- 리뷰 상세정보를 조회할 때 이벤트 id, 상호명, 해시태그를 반환

## ETC
